### PR TITLE
Let an app bring the database it already has

### DIFF
--- a/apps/web/lib/app-config.ts
+++ b/apps/web/lib/app-config.ts
@@ -47,9 +47,44 @@ export interface ScaleConfig {
   cpuBoost?: boolean;
 }
 
+/**
+ * A database the platform creates, owns and injects. The default, and the whole
+ * zero-config promise: nothing is declared, Postgres appears, seventeen variable
+ * names point at it.
+ */
+export interface ManagedDatabase {
+  provider: "managed";
+  engine: "postgres";
+  version?: string;
+}
+
+/**
+ * A database that already exists and that the platform must not touch.
+ *
+ * This is the mode that was inexpressible, and its absence excluded every app
+ * with infrastructure of its own — anything already on Supabase, Neon or an RDS
+ * instance. Not because such an app is hard to run: because `resources.database`
+ * was a boolean in disguise, where present meant PROVISION, so there was nowhere
+ * to say "there is a database and it is not yours".
+ *
+ * `urlFrom` is a secret NAME, never a URL. The platform does not need to know the
+ * connection string — only that a value exists under that name and reached the
+ * revision — so the credential travels the same path as every other secret and is
+ * never committed to a file.
+ */
+export interface ExternalDatabase {
+  provider: "external";
+  /** Free-form, for the log line only. Nothing is provisioned, so nothing validates it. */
+  engine?: string;
+  /** The SECRET NAME holding the connection URL — "DATABASE_URL". Never the URL itself. */
+  urlFrom: string;
+}
+
+export type DatabaseConfig = ManagedDatabase | ExternalDatabase;
+
 /** Provisioned once per APP, not once per service. Two services share one database. */
 export interface ResourcesConfig {
-  database?: { engine: "postgres"; version?: string };
+  database?: DatabaseConfig;
   bucket?: boolean;
 }
 
@@ -164,7 +199,18 @@ export class ConfigError extends Error {}
 const LANGUAGES = new Set(["node", "python", "static", "other"]);
 
 /**
- * Names the platform writes, which a config may therefore not declare.
+ * Ours no matter what the app declares.
+ *
+ * `PORT` is assigned by Cloud Run and injected into the ingress container, and the
+ * runtime contract says so outright; `SUPERSONIC_*` is this platform's own
+ * namespace. Neither depends on anything the app asked for, so neither is ever
+ * released back.
+ */
+const ALWAYS_OWNED_PREFIXES = [/^SUPERSONIC_/];
+const ALWAYS_OWNED_EXACT = new Set(["PORT"]);
+
+/**
+ * Ours only while we are the one writing them.
  *
  * Derived from `databaseEnv()` rather than typed out again. The two lists were
  * maintained separately once — 6 protected names against 17 written — and every
@@ -172,15 +218,31 @@ const LANGUAGES = new Set(["node", "python", "static", "other"]);
  * to the user as their own config being ignored.
  *
  * The prefixes are deliberately broad. `PGSSLMODE` is not written by
- * `databaseEnv()` today, but it configures the same connection the platform owns,
- * and a user setting it is describing a connection they do not control. Refusing
- * it by name is a better failure than honouring it into a contradiction.
+ * `databaseEnv()` today, but it configures the same connection, and a user setting
+ * it while the platform supplies the endpoint is describing a connection they do
+ * not control.
  */
-const PLATFORM_OWNED_PREFIXES = [/^POSTGRES_/, /^PG/, /^DB_/, /^SUPERSONIC_/];
-const PLATFORM_OWNED_EXACT = new Set([...databaseEnvNames(), "PORT"]);
+const DATABASE_OWNED_PREFIXES = [/^POSTGRES_/, /^PG/, /^DB_/];
+const DATABASE_OWNED_EXACT = new Set(databaseEnvNames());
 
-export function platformOwned(name: string): boolean {
-  return PLATFORM_OWNED_EXACT.has(name) || PLATFORM_OWNED_PREFIXES.some((re) => re.test(name));
+/**
+ * Whether a name belongs to the platform rather than to the app.
+ *
+ * The rule turns on FACT, not on intent: these names are ours precisely when we
+ * provision the database that gives them meaning. Unconditionally, they were a
+ * refusal aimed at the wrong app. The reasoning behind the original block —
+ * "somebody setting DATABASE_URL is describing a database they do not have" — is
+ * true of an app the platform supplies, and exactly inverted for an app on
+ * Supabase: it has the database, and the platform was refusing to accept it.
+ *
+ * So the same seventeen names are a parse error under `provider: "managed"` and
+ * the app's own business under `provider: "external"` or with no database at all.
+ * One rule, applied to what the deploy will actually do.
+ */
+export function platformOwned(name: string, database?: DatabaseConfig): boolean {
+  if (ALWAYS_OWNED_EXACT.has(name) || ALWAYS_OWNED_PREFIXES.some((re) => re.test(name))) return true;
+  if (database?.provider !== "managed") return false;
+  return DATABASE_OWNED_EXACT.has(name) || DATABASE_OWNED_PREFIXES.some((re) => re.test(name));
 }
 
 /** A path that stays inside the repo. */
@@ -219,7 +281,7 @@ function num(v: unknown, where: string): number | undefined {
  * finding it out at the least useful moment. The message names the variable
  * because "invalid configuration" sends someone reading the whole file.
  */
-function literals(v: unknown, where: string): Record<string, string> | undefined {
+function literals(v: unknown, where: string, database?: DatabaseConfig): Record<string, string> | undefined {
   if (v === undefined || v === null) return undefined;
   if (typeof v !== "object" || Array.isArray(v)) {
     // Both spellings are named, because `env` is the one field whose meaning
@@ -229,10 +291,10 @@ function literals(v: unknown, where: string): Record<string, string> | undefined
   }
   const out: Record<string, string> = {};
   for (const [k, raw] of Object.entries(v as Record<string, unknown>)) {
-    if (platformOwned(k)) {
+    if (platformOwned(k, database)) {
       throw new ConfigError(
         `${where}: "${k}" is set by the platform and cannot be declared here. ` +
-        `Remove it — the value the app receives is the one the platform provisions.`,
+        ownedBecause(k, database),
       );
     }
     if (typeof raw !== "string" && typeof raw !== "number" && typeof raw !== "boolean") {
@@ -243,14 +305,37 @@ function literals(v: unknown, where: string): Record<string, string> | undefined
   return out;
 }
 
-function names(v: unknown, where: string): string[] | undefined {
+/**
+ * Why a name was refused, and what to do instead.
+ *
+ * The two cases need different advice and used to share one sentence. Under a
+ * managed database the answer is "remove it"; a name refused because it is
+ * `PORT` or `SUPERSONIC_*` can never be un-refused, and saying "the platform
+ * provisions it" to someone who declared PORT explains nothing. The third case is
+ * the one this exists for: an app that HAS a database and wants to name it should
+ * be told which line to write, not merely told no.
+ */
+function ownedBecause(name: string, database?: DatabaseConfig): string {
+  if (ALWAYS_OWNED_EXACT.has(name) || ALWAYS_OWNED_PREFIXES.some((re) => re.test(name))) {
+    return name === "PORT"
+      ? `Cloud Run assigns the port and injects it — read it from the environment instead.`
+      : `SUPERSONIC_* is the platform's own namespace.`;
+  }
+  return (
+    `The platform provisions this app's database, so it writes this value itself. ` +
+    `If the app already HAS a database, declare it instead: ` +
+    `"resources": { "database": { "provider": "external", "urlFrom": "${name}" } }`
+  );
+}
+
+function names(v: unknown, where: string, database?: DatabaseConfig): string[] | undefined {
   if (v === undefined || v === null) return undefined;
   if (!Array.isArray(v) || v.some((e) => typeof e !== "string")) {
     throw new ConfigError(`${where} must be an array of variable NAMES`);
   }
   for (const n of v as string[]) {
-    if (platformOwned(n)) {
-      throw new ConfigError(`${where}: "${n}" is set by the platform and cannot be declared here.`);
+    if (platformOwned(n, database)) {
+      throw new ConfigError(`${where}: "${n}" is set by the platform and cannot be declared here. ` + ownedBecause(n, database));
     }
   }
   return v as string[];
@@ -292,15 +377,48 @@ function resources(v: unknown): ResourcesConfig | undefined {
   const where = `${CONFIG_FILENAME} resources`;
   if (typeof v !== "object" || Array.isArray(v)) throw new ConfigError(`${where} must be an object`);
   const o = v as Record<string, unknown>;
-  let database: ResourcesConfig["database"];
+  let database: DatabaseConfig | undefined;
   if (o.database !== undefined && o.database !== null && o.database !== false) {
     if (typeof o.database !== "object" || Array.isArray(o.database)) {
       throw new ConfigError(`${where}.database must be an object`);
     }
     const d = o.database as Record<string, unknown>;
-    const engine = str(d.engine, `${where}.database.engine`) ?? "postgres";
-    if (engine !== "postgres") throw new ConfigError(`${where}.database.engine: only "postgres" is provisioned today (got ${JSON.stringify(engine)})`);
-    database = { engine: "postgres", version: str(d.version, `${where}.database.version`) };
+    // Defaulted rather than required, so every file written before this field
+    // existed keeps meaning exactly what it meant. "managed" is what the platform
+    // has always done.
+    const provider = str(d.provider, `${where}.database.provider`) ?? "managed";
+    if (provider !== "managed" && provider !== "external") {
+      throw new ConfigError(
+        `${where}.database.provider must be "managed" (the platform creates it) or "external" ` +
+        `(it already exists and the platform only injects it) — got ${JSON.stringify(provider)}`,
+      );
+    }
+    if (provider === "external") {
+      const urlFrom = str(d.urlFrom, `${where}.database.urlFrom`)?.trim();
+      if (!urlFrom) {
+        throw new ConfigError(
+          `${where}.database: an external database needs "urlFrom" — the NAME of the secret holding its ` +
+          `connection URL, for example "DATABASE_URL". The value itself belongs in your .env or in ` +
+          `\`supersonic env set\`, never in this file.`,
+        );
+      }
+      // Refused here rather than at deploy time: an external database whose URL is
+      // said to live in PORT is a file that cannot be honoured, and finding that
+      // out after provisioning is finding it out at the least useful moment.
+      if (platformOwned(urlFrom)) {
+        throw new ConfigError(`${where}.database.urlFrom: "${urlFrom}" is set by the platform and cannot hold your connection URL.`);
+      }
+      database = { provider: "external", engine: str(d.engine, `${where}.database.engine`), urlFrom };
+    } else {
+      const engine = str(d.engine, `${where}.database.engine`) ?? "postgres";
+      if (engine !== "postgres") {
+        throw new ConfigError(
+          `${where}.database.engine: only "postgres" is provisioned today (got ${JSON.stringify(engine)}). ` +
+          `An ${engine} the app already has can be declared with "provider": "external".`,
+        );
+      }
+      database = { provider: "managed", engine: "postgres", version: str(d.version, `${where}.database.version`) };
+    }
   }
   return { database, bucket: o.bucket === undefined ? undefined : Boolean(o.bucket) };
 }
@@ -323,6 +441,16 @@ export function parseAppConfig(text: string): AppConfig {
   if (!Array.isArray(o.services) || o.services.length === 0) {
     throw new ConfigError(`${CONFIG_FILENAME} needs a non-empty "services" array`);
   }
+  // Resources FIRST, and then the services against them.
+  //
+  // The order is load-bearing now that a name is refused on the strength of what
+  // the deploy will do rather than on the strength of its spelling: whether
+  // DATABASE_URL belongs to the platform or to the app is decided by
+  // `resources.database`, so validating a service's `env` before knowing the
+  // answer would refuse the very configuration this supports. The services are
+  // scanned for `uses`/`needsDB` first because those OR into the same decision.
+  const declaredResources = resources(o.resources);
+  const database = declaredDatabase(declaredResources, o.services);
   const services = o.services.map((s, i): ServiceConfig => {
     const where = `${CONFIG_FILENAME} services[${i}]`;
     if (!s || typeof s !== "object" || Array.isArray(s)) throw new ConfigError(`${where} must be an object`);
@@ -339,7 +467,7 @@ export function parseAppConfig(text: string): AppConfig {
     // turning a field that was only ever logged into one that fails the deploy
     // would break working apps on a rename.
     const envIsNameList = Array.isArray(svc.env);
-    const uses = svc.uses === undefined ? undefined : names(svc.uses, `${where}.uses`);
+    const uses = svc.uses === undefined ? undefined : names(svc.uses, `${where}.uses`, database);
     for (const u of uses ?? []) {
       if (u !== "database" && u !== "bucket") {
         throw new ConfigError(`${where}.uses: "${u}" is not a resource — expected "database" or "bucket"`);
@@ -362,10 +490,10 @@ export function parseAppConfig(text: string): AppConfig {
       context: svc.context === undefined ? undefined : safeDir(svc.context, `${where}.context`),
       needsDB: svc.needsDB === undefined ? undefined : Boolean(svc.needsDB),
       uses: uses as ServiceConfig["uses"],
-      env: envIsNameList ? undefined : literals(svc.env, `${where}.env`),
-      envNeeded: envIsNameList ? names(svc.env, `${where}.env`) : undefined,
-      buildEnv: literals(svc.buildEnv, `${where}.buildEnv`),
-      secrets: names(svc.secrets, `${where}.secrets`),
+      env: envIsNameList ? undefined : literals(svc.env, `${where}.env`, database),
+      envNeeded: envIsNameList ? names(svc.env, `${where}.env`, database) : undefined,
+      buildEnv: literals(svc.buildEnv, `${where}.buildEnv`, database),
+      secrets: names(svc.secrets, `${where}.secrets`, database),
       health: health(svc.health, `${where}.health`),
       scale: scale(svc.scale, `${where}.scale`),
       path: str(svc.path, `${where}.path`),
@@ -392,9 +520,29 @@ export function parseAppConfig(text: string): AppConfig {
   }
   return {
     version: typeof o.version === "number" ? o.version : 1,
-    resources: appResources(resources(o.resources), services),
+    resources: appResources(declaredResources, services),
     services,
   };
+}
+
+/**
+ * The database mode, decided before the services have been validated against it.
+ *
+ * A chicken-and-egg that has to be broken somewhere: `uses: ["database"]` on any
+ * service means the app gets a managed database, and whether a service may
+ * declare DATABASE_URL depends on that answer — so the raw services are scanned
+ * for the two spellings before any of them is parsed. Deliberately permissive
+ * about shape, because a malformed service is reported by the parser below with a
+ * far better message than anything this could say.
+ */
+function declaredDatabase(declared: ResourcesConfig | undefined, rawServices: unknown[]): DatabaseConfig | undefined {
+  if (declared?.database) return declared.database;
+  const wants = rawServices.some((s) => {
+    if (!s || typeof s !== "object" || Array.isArray(s)) return false;
+    const svc = s as Record<string, unknown>;
+    return Boolean(svc.needsDB) || (Array.isArray(svc.uses) && svc.uses.includes("database"));
+  });
+  return wants ? { provider: "managed", engine: "postgres" } : undefined;
 }
 
 /**
@@ -409,7 +557,12 @@ export function parseAppConfig(text: string): AppConfig {
 export function appResources(declared: ResourcesConfig | undefined, services: ServiceConfig[]): ResourcesConfig | undefined {
   const wantsDb = services.some(usesDatabase);
   const wantsBucket = services.some((s) => (s.uses ?? []).includes("bucket"));
-  const database = declared?.database ?? (wantsDb ? { engine: "postgres" as const } : undefined);
+  // A service asking for a database without the app saying whose it is gets the
+  // platform's, which is what `needsDB` has always meant. An app that owns its own
+  // has to say so at the top level, because there is nothing about `uses:
+  // ["database"]` that could carry a connection URL.
+  const database: DatabaseConfig | undefined =
+    declared?.database ?? (wantsDb ? { provider: "managed", engine: "postgres" } : undefined);
   const bucket = declared?.bucket ?? (wantsBucket ? true : undefined);
   if (!database && bucket === undefined) return declared;
   return { database, bucket };

--- a/apps/web/lib/deploy-pipeline.ts
+++ b/apps/web/lib/deploy-pipeline.ts
@@ -10,7 +10,7 @@ import { checkPlanDeps, assertRuntimeSupported, RUNTIME_UNSUPPORTED } from "@/li
 import { readRepoFacts, refusalReason } from "@/lib/repo-facts";
 import { planKey, getCachedPlan, putCachedPlan } from "@/lib/plan-cache";
 import { snapshotSources, repairPatch } from "@/lib/repair-diff";
-import { putAppSecrets, setSecretsFlag, grantBuildAccess, type SecretRef } from "@/lib/app-secrets";
+import { putAppSecrets, setSecretsFlag, grantBuildAccess, readAppSecret, type SecretRef } from "@/lib/app-secrets";
 import { cloudRunName } from "@/lib/slug";
 import { readAppConfig, planFromConfig, ConfigError, CONFIG_FILENAME, primaryService, extraServices, servicePath, usesDatabase, type ServiceConfig, type AppConfig, type HealthConfig } from "@/lib/app-config";
 import { inferAppConfig, type DetectedStack } from "@/lib/infer-services";
@@ -1286,12 +1286,52 @@ export async function runDeploy(input: DeployInput, emit: (e: unknown) => void):
     // the bucket get created while Cloud Build is already working. Both
     // settle rather than reject: a missing bucket has always been survivable,
     // and starting them early must not change that.
-    const pgPromise = s.database?.engine === "postgres"
+    // Whose database this is decides whether anything is provisioned at all.
+    //
+    // An app that already has one — Supabase, Neon, an RDS instance — gets its
+    // connection from its own secret and nothing else happens: no Cloud SQL
+    // database, no per-app role, and no proxy container beside it. That last
+    // omission is the reason this mode is simpler rather than more complex, since
+    // the sidecar is what drags in the container-scoped argv, the mandatory
+    // startup probe and the one-container-must-declare-a-port rule.
+    const externalDb = appConfig?.resources?.database?.provider === "external"
+      ? appConfig.resources.database
+      : null;
+    const pgPromise = !externalDb && s.database?.engine === "postgres"
       ? provisionPostgres(slug, log).then(
           (pg) => ({ ok: true as const, pg }),
           (e) => ({ ok: false as const, error: e instanceof Error ? e.message : String(e) }),
         )
       : null;
+    if (externalDb) {
+      // Said out loud, because "no database was provisioned" and "the database is
+      // yours" look identical in a log otherwise, and the first is a failure.
+      log(`Using your own ${externalDb.engine ?? "database"} — reading its URL from ${externalDb.urlFrom}, provisioning nothing`);
+      // Before the build, not at container start.
+      //
+      // `missingSecrets` has existed since schema v2 and was called from exactly
+      // one place: `supersonic check`, on the user's machine. So the rule the
+      // schema calls ENFORCED was enforced only by the tool a deploy does not have
+      // to run through. For a managed database that was survivable, because the
+      // platform supplied the connection either way; for one the app owns, the
+      // missing value IS the deploy, and the first thing to notice it would have
+      // been the app's own driver, nine minutes later, inside a crash loop.
+      //
+      // Checked against Secret Manager and not only against this deploy's upload:
+      // a value set on an earlier deploy, or with `supersonic env set`, is still
+      // set. Failing an app whose secret was stored last week is the same mistake
+      // assertReached made once already, pointed at a different field.
+      const uploaded = Boolean(secrets[externalDb.urlFrom]);
+      const stored = uploaded ? true : Boolean(await readAppSecret(slug, externalDb.urlFrom).catch(() => null));
+      if (!stored) {
+        throw new Error(
+          `${CONFIG_FILENAME} declares an external database whose URL comes from ${externalDb.urlFrom}, ` +
+          `and nothing has set a value for it.\n` +
+          `  Put ${externalDb.urlFrom} in your .env, or run \`supersonic env ${friendlyName} set ${externalDb.urlFrom}=…\`, then deploy again.\n` +
+          `  Nothing was provisioned and nothing was built — this stopped before either.`,
+        );
+      }
+    }
     const storagePromise = provisionStorage(slug, log).then(
       (bucket) => ({ ok: true as const, bucket }),
       (e) => ({ ok: false as const, error: e instanceof Error ? e.message : String(e) }),

--- a/apps/web/lib/envelope.ts
+++ b/apps/web/lib/envelope.ts
@@ -55,6 +55,18 @@ export interface ServiceEnvelope {
   scale: Scale;
 
   /**
+   * The secret NAME carrying an external database's URL, when the app owns its
+   * own database. Absent for a managed one, where the platform writes the
+   * connection itself.
+   *
+   * An app-level fact rather than a service-level one, carried on the envelope
+   * because this is the object the checks below read, and `uses: ["database"]`
+   * means two different observable things depending on it: a database the
+   * platform provisioned, or a secret reference that reached the revision.
+   */
+  dbUrlName?: string;
+
+  /**
    * What the AUTHOR wrote, carried through from the resolver.
    *
    * Not re-derived from the values here, because it cannot be: `health` and
@@ -70,7 +82,8 @@ export interface ServiceEnvelope {
 /** Which envelope fields the AUTHOR actually declared, in envelope terms. */
 export type Declared = ReadonlyArray<keyof ServiceEnvelope>;
 
-export function buildEnvelope(service: ResolvedService, _app: ResolvedApp): ServiceEnvelope {
+export function buildEnvelope(service: ResolvedService, app: ResolvedApp): ServiceEnvelope {
+  const db = app.resources?.database;
   return {
     name: service.name,
     dir: service.dir,
@@ -92,6 +105,7 @@ export function buildEnvelope(service: ResolvedService, _app: ResolvedApp): Serv
     uses: service.uses,
     health: service.health,
     scale: service.scale,
+    dbUrlName: db?.provider === "external" ? db.urlFrom : undefined,
     declared: service.declared as Declared,
   };
 }
@@ -100,7 +114,7 @@ export function buildEnvelope(service: ResolvedService, _app: ResolvedApp): Serv
  * Fields that carry a value on every service whether or not anyone asked for
  * them, so reading them proves nothing and not reading them means nothing.
  */
-const NEVER_ASSERTED = new Set<string>(["name", "dir", "path", "lane", "declared"]);
+const NEVER_ASSERTED = new Set<string>(["name", "dir", "path", "lane", "declared", "dbUrlName"]);
 
 export interface Tracked {
   envelope: ServiceEnvelope;
@@ -200,7 +214,17 @@ const REACHED: Partial<Record<keyof ServiceEnvelope, (e: ServiceEnvelope, o: Dep
   // one, so `secrets` is the field where HOW it arrived is the whole point.
   secrets: (e, o) => !o.hasRevision || e.secrets.every((s) => carries(o, s, true)),
   release: (e, o) => o.releaseCommand.trim() !== "",
-  uses: (e, o) => !e.uses.includes("database") || o.hasDatabase,
+  // What counts as "the database reached the app" depends on whose database it
+  // is, and both halves have to be checked or the new mode becomes the next
+  // declared-and-ignored field — the exact class this module exists to end.
+  // Managed: provisioning ran. External: the connection secret is mounted on the
+  // revision, by reference, which is the only observable the platform has and the
+  // only one it needs.
+  uses: (e, o) => {
+    if (!e.uses.includes("database")) return true;
+    if (e.dbUrlName) return !o.hasRevision || carries(o, e.dbUrlName, true);
+    return o.hasDatabase;
+  },
   scale: (e, o) => o.argv.includes(e.scale.memory) && o.argv.includes(`--timeout=${e.scale.timeout}`),
   // Read by the verifier after the revision is live rather than by the argv, so
   // its effect is not visible here. Present so it is not reported unverifiable.

--- a/apps/web/lib/resolve.ts
+++ b/apps/web/lib/resolve.ts
@@ -372,6 +372,13 @@ export function validate(app: ResolvedApp, dir: string): void {
 export function missingSecrets(app: ResolvedApp, available: Iterable<string>): string[] {
   const have = new Set(available);
   const want = new Set(app.services.flatMap((s) => s.secrets));
+  // An external database's URL is a required secret by construction: the app
+  // declared that it has a database and named where its connection string lives,
+  // and nothing else supplies one. Left out of this set it would fail at container
+  // start, inside the customer's own stack trace, which is precisely where a value
+  // the platform already knew was missing must not first be noticed.
+  const db = app.resources.database;
+  if (db?.provider === "external") want.add(db.urlFrom);
   return [...want].filter((n) => !have.has(n)).sort();
 }
 

--- a/apps/web/test/envelope.test.ts
+++ b/apps/web/test/envelope.test.ts
@@ -145,6 +145,40 @@ test("uses: [database] with no database provisioned fails the deploy", () => {
   assert.doesNotThrow(() => assertReached(e, outcome({ hasDatabase: true })));
 });
 
+test("uses: [database] on an external database is proved by the secret, not by provisioning", () => {
+  // The same declaration means two different observable things depending on whose
+  // database it is, and checking only the platform's half would let the new mode
+  // become the next field that is declared, valid, and acted on by nobody —
+  // which is the failure this module was written for.
+  const external = {
+    source: "config",
+    resources: { database: { provider: "external", urlFrom: "DATABASE_URL" } },
+    services: [],
+  } as unknown as ResolvedApp;
+  const e = buildEnvelope(service({ uses: ["database"], declared: ["uses"] }), external);
+
+  // Provisioning did not run, and must not be what this asks about.
+  assert.throws(() => assertReached(e, outcome({ hasDatabase: false })), /did not apply: uses/);
+  assert.doesNotThrow(() =>
+    assertReached(e, outcome({ revisionEnv: [{ name: "DATABASE_URL", fromSecret: true }] })));
+});
+
+test("an external database URL arriving as a plain variable does not count", () => {
+  // A credential written verbatim into the revision spec has reached the app and
+  // defeated the reason for it being a secret — the same distinction `secrets`
+  // already turns on.
+  const external = {
+    source: "config",
+    resources: { database: { provider: "external", urlFrom: "DATABASE_URL" } },
+    services: [],
+  } as unknown as ResolvedApp;
+  const e = buildEnvelope(service({ uses: ["database"], declared: ["uses"] }), external);
+  assert.throws(
+    () => assertReached(e, outcome({ revisionEnv: [{ name: "DATABASE_URL", fromSecret: false }] })),
+    /did not apply: uses/,
+  );
+});
+
 test("a declared secret that never got mounted fails the deploy", () => {
   const e = buildEnvelope(service({ secrets: ["STRIPE_KEY"], declared: ["secrets"] }), app);
   assert.throws(() => assertReached(e, outcome()), /did not apply: secrets/);

--- a/apps/web/test/resolve.test.ts
+++ b/apps/web/test/resolve.test.ts
@@ -191,7 +191,7 @@ test("a service that uses a resource has it provisioned, whatever the config's s
     }),
   });
   const app = await resolve(dir);
-  assert.deepEqual(app.resources.database, { engine: "postgres" });
+  assert.deepEqual(app.resources.database, { provider: "managed", engine: "postgres" });
   assert.equal(app.resources.bucket, true);
   assert.doesNotThrow(() => validate(app, dir));
 });
@@ -228,7 +228,7 @@ test("a sibling that needs a database gets the app one provisioned", () => {
       { name: "api", language: "python", start: "gunicorn app:app", path: "/api", needsDB: true },
     ],
   }));
-  assert.deepEqual(cfg.resources?.database, { engine: "postgres" });
+  assert.deepEqual(cfg.resources?.database, { provider: "managed", engine: "postgres" });
 });
 
 test("uses: [database] provisions one too, without the deprecated shorthand", () => {
@@ -236,7 +236,7 @@ test("uses: [database] provisions one too, without the deprecated shorthand", ()
     version: 1,
     services: [{ language: "python", start: "x", uses: ["database"] }],
   }));
-  assert.deepEqual(cfg.resources?.database, { engine: "postgres" });
+  assert.deepEqual(cfg.resources?.database, { provider: "managed", engine: "postgres" });
 });
 
 test("an explicitly declared database keeps its version", () => {
@@ -245,16 +245,73 @@ test("an explicitly declared database keeps its version", () => {
     resources: { database: { engine: "postgres", version: "16" }, bucket: true },
     services: [{ language: "python", start: "x" }],
   }));
-  assert.deepEqual(cfg.resources?.database, { engine: "postgres", version: "16" });
+  assert.deepEqual(cfg.resources?.database, { provider: "managed", engine: "postgres", version: "16" });
   assert.equal(cfg.resources?.bucket, true);
+});
+
+/* ── bring your own database ─────────────────────────────────────────────── */
+
+test("a database declared external is not provisioned and names its secret", () => {
+  const cfg = parseAppConfig(config({
+    version: 1,
+    resources: { database: { provider: "external", engine: "postgres", urlFrom: "DATABASE_URL" } },
+    services: [{ language: "python", start: "x", uses: ["database"] }],
+  }));
+  assert.deepEqual(cfg.resources?.database, { provider: "external", engine: "postgres", urlFrom: "DATABASE_URL" });
+});
+
+test("an external database must say which secret holds its URL", () => {
+  assert.throws(
+    () => parseAppConfig(config({
+      version: 1,
+      resources: { database: { provider: "external" } },
+      services: [{ language: "python", start: "x" }],
+    })),
+    /needs "urlFrom"/,
+  );
+});
+
+test("urlFrom cannot name a variable the platform always owns", () => {
+  assert.throws(
+    () => parseAppConfig(config({
+      version: 1,
+      resources: { database: { provider: "external", urlFrom: "PORT" } },
+      services: [{ language: "python", start: "x" }],
+    })),
+    /"PORT" is set by the platform/,
+  );
+});
+
+test("provider must be managed or external, and says so", () => {
+  assert.throws(
+    () => parseAppConfig(config({
+      version: 1,
+      resources: { database: { provider: "supabase", urlFrom: "DATABASE_URL" } },
+      services: [{ language: "python", start: "x" }],
+    })),
+    /must be "managed".*or "external"/,
+  );
+});
+
+test("an engine the platform cannot provision points at the external escape hatch", () => {
+  assert.throws(
+    () => parseAppConfig(config({
+      version: 1,
+      resources: { database: { engine: "mysql" } },
+      services: [{ language: "python", start: "x" }],
+    })),
+    /can be declared with "provider": "external"/,
+  );
 });
 
 /* ── parse-time rules ────────────────────────────────────────────────────── */
 
+const MANAGED = { database: { engine: "postgres" } };
+
 test("a platform-owned variable is a parse error naming the variable", () => {
   for (const name of ["DATABASE_URL", "POSTGRES_USER", "PGPASSWORD", "DB_NAME", "PORT", "SUPERSONIC_RUN"]) {
     assert.throws(
-      () => parseAppConfig(config({ version: 1, services: [{ env: { [name]: "x" } }] })),
+      () => parseAppConfig(config({ version: 1, resources: MANAGED, services: [{ env: { [name]: "x" } }] })),
       (e: Error) => {
         assert.ok(e instanceof ConfigError);
         assert.match(e.message, new RegExp(`"${name}" is set by the platform`));
@@ -268,16 +325,59 @@ test("a platform-owned variable is a parse error naming the variable", () => {
 test("the protected set covers every name databaseEnv writes, by derivation", () => {
   // 6 names were protected while 17 were written. Everything in the gap was a
   // user value the platform silently overwrote.
-  assert.ok(platformOwned("POSTGRES_SERVER"));
-  assert.ok(platformOwned("PGHOST"));
-  assert.ok(platformOwned("DB_PASSWORD"));
-  assert.ok(!platformOwned("STRIPE_SECRET_KEY"));
-  assert.ok(!platformOwned("LOG_LEVEL"));
+  const managed = { provider: "managed", engine: "postgres" } as const;
+  assert.ok(platformOwned("POSTGRES_SERVER", managed));
+  assert.ok(platformOwned("PGHOST", managed));
+  assert.ok(platformOwned("DB_PASSWORD", managed));
+  assert.ok(!platformOwned("STRIPE_SECRET_KEY", managed));
+  assert.ok(!platformOwned("LOG_LEVEL", managed));
+});
+
+test("PORT and SUPERSONIC_* are ours whatever the app declares", () => {
+  // Nothing releases these: Cloud Run assigns the port, and SUPERSONIC_* is the
+  // platform's own namespace. They do not depend on who supplies the database.
+  for (const db of [undefined, { provider: "managed", engine: "postgres" } as const,
+                    { provider: "external", urlFrom: "DATABASE_URL" } as const]) {
+    assert.ok(platformOwned("PORT", db));
+    assert.ok(platformOwned("SUPERSONIC_RUN", db));
+  }
+});
+
+test("database names belong to the app when the platform does not supply one", () => {
+  // The refusal that excluded every app with infrastructure of its own. The
+  // original reasoning — "somebody setting DATABASE_URL is describing a database
+  // they do not have" — is exactly inverted for an app on Supabase.
+  const external = { provider: "external", urlFrom: "DATABASE_URL" } as const;
+  assert.ok(!platformOwned("DATABASE_URL", external));
+  assert.ok(!platformOwned("PGHOST", external));
+  assert.ok(!platformOwned("DATABASE_URL", undefined));
+});
+
+test("an app that owns its database may declare the connection names", () => {
+  const cfg = parseAppConfig(config({
+    version: 1,
+    resources: { database: { provider: "external", urlFrom: "DATABASE_URL" } },
+    services: [{ language: "python", start: "x", uses: ["database"], secrets: ["DATABASE_URL"], env: { PGSSLMODE: "require" } }],
+  }));
+  assert.deepEqual(cfg.services[0].secrets, ["DATABASE_URL"]);
+  assert.deepEqual(cfg.services[0].env, { PGSSLMODE: "require" });
+});
+
+test("refusing a database name points at the way to declare one", () => {
+  // A refusal that only says no leaves the author with no next move. This is the
+  // whole reason the name was refused, so it is the right place to say it.
+  assert.throws(
+    () => parseAppConfig(config({ version: 1, resources: MANAGED, services: [{ env: { DATABASE_URL: "x" } }] })),
+    /"provider": "external", "urlFrom": "DATABASE_URL"/,
+  );
 });
 
 test("a platform-owned name is refused in buildEnv and secrets too, not only env", () => {
   assert.throws(() => parseAppConfig(config({ version: 1, services: [{ buildEnv: { PORT: "3000" } }] })), /set by the platform/);
-  assert.throws(() => parseAppConfig(config({ version: 1, services: [{ secrets: ["DATABASE_URL"] }] })), /set by the platform/);
+  assert.throws(
+    () => parseAppConfig(config({ version: 1, resources: MANAGED, services: [{ secrets: ["DATABASE_URL"] }] })),
+    /set by the platform/,
+  );
 });
 
 test("release and preDeploy are the same field and cannot disagree", () => {
@@ -335,6 +435,35 @@ test("a declared secret with no value anywhere is reported by name", () => {
     assert.deepEqual(missingSecrets(app, ["SENTRY_DSN"]), ["STRIPE_SECRET_KEY"]);
     assert.deepEqual(missingSecrets(app, ["SENTRY_DSN", "STRIPE_SECRET_KEY"]), []);
   });
+});
+
+test("an external database's URL is a required secret without anyone listing it", () => {
+  // Required by construction: the app said it has a database and said where the
+  // connection string lives, and nothing else supplies one. Left out of this set
+  // it would surface as a driver error inside the customer's own stack trace.
+  const dir = repo({
+    "app.py": "x = 1",
+    "supersonic.json": config({
+      version: 1,
+      resources: { database: { provider: "external", urlFrom: "DATABASE_URL" } },
+      services: [{ language: "python", start: "x", uses: ["database"] }],
+    }),
+  });
+  return resolve(dir).then((app) => {
+    assert.deepEqual(missingSecrets(app, []), ["DATABASE_URL"]);
+    assert.deepEqual(missingSecrets(app, ["DATABASE_URL"]), []);
+  });
+});
+
+test("a managed database asks for no secret of its own", () => {
+  const dir = repo({
+    "app.py": "x = 1",
+    "supersonic.json": config({
+      version: 1,
+      services: [{ language: "python", start: "x", uses: ["database"] }],
+    }),
+  });
+  return resolve(dir).then((app) => assert.deepEqual(missingSecrets(app, []), []));
 });
 
 /* ── the simplest possible file stays the fastest path ───────────────────── */

--- a/docs/DEPLOY-PLAN.md
+++ b/docs/DEPLOY-PLAN.md
@@ -162,7 +162,13 @@ Three rules:
   // Provisioned ONCE per app. Today provisioning is driven by the PRIMARY service's
   // plan, so a sibling that needs a database does not get one.
   "resources": {
-    "database": { "engine": "postgres", "version": "16" },
+    // "provider" defaults to "managed" — the platform creates it and injects the
+    // connection under all seventeen names. An app that already HAS a database
+    // says so instead, and nothing is provisioned:
+    //   "database": { "provider": "external", "engine": "postgres", "urlFrom": "DATABASE_URL" }
+    // `urlFrom` is a secret NAME, never a URL. The value lives in .env or in
+    // `supersonic env set`, and the deploy stops before the build if it is unset.
+    "database": { "provider": "managed", "engine": "postgres", "version": "16" },
     "bucket": true
   },
 
@@ -212,6 +218,7 @@ Three rules:
 | Field | Why | Closes |
 |---|---|---|
 | `resources.database` (top level) | Provisioning is once per app; two services share one database. `needsDB` stays as a deprecated per-service shorthand that ORs in. | provisioner bug |
+| `database.provider` + `urlFrom` | `resources.database` was a boolean in disguise — present meant PROVISION — so there was nowhere to say "there is a database and it is not yours". That excluded every app with infrastructure of its own. | goal: any existing app |
 | `uses: [...]` | Says which services receive credentials — the unit per-app DB isolation is scoped to. | goal: per-app DB |
 | `runtime` | The pipeline detects `requires-python >= 3.14`, logs "the build will probably fail on it", and builds anyway. | #28, #29 |
 | `framework` | One token letting the platform inject proxy-awareness. The app cannot configure for a proxy it does not know exists. | #14, #15 |
@@ -226,11 +233,14 @@ Three rules:
 
 **Three parse-time rules:**
 
-1. **Platform-owned names are a parse error.** If the file or the `.env` declares `DATABASE_URL`,
-   any `POSTGRES_*`, `PG*`, `DB_*`, `PORT`, or `SUPERSONIC_*` — fail, naming the variable.
-   `PLATFORM_OWNED` (`envfile.js:29-36`) lists 6 names; `databaseEnv()`
-   (`deploy-pipeline.ts:324-334`) sets 17. The fix is not adding 11 names — it is **deriving the
-   protected set from `databaseEnv()`** so it can never drift again. (#18, #19)
+1. **Platform-owned names are a parse error — when they are ours.** `PORT` and `SUPERSONIC_*`
+   always are. `DATABASE_URL`, `POSTGRES_*`, `PG*` and `DB_*` are ours **only while we provision
+   the database**, because the rule turns on fact rather than on intent. The original reasoning —
+   "somebody setting DATABASE_URL is describing a database they do not have" — is true of an app
+   the platform supplies and exactly inverted for an app on Supabase, which has the database while
+   the platform refuses to accept it. Under `provider: "external"`, or with no database at all,
+   those names are the app's own. The protected set is still **derived from `databaseEnv()`** so it
+   cannot drift, and the refusal message now names the line to write instead. (#18, #19)
 2. **`secrets[]` is enforced.** Today `envNeeded` is logged at `:1139` and checked nowhere.
 3. **`LOCAL_HOSTS` becomes per-value, not whole-value.** `envfile.js:40,112` drops any value
    *containing* `localhost`, so `CORS_ORIGINS=https://app.com,http://localhost:3000` is dropped
@@ -852,6 +862,7 @@ found" below.*
 | 3 — single-consumer executor | **not started** | lanes still read three objects for the same facts |
 | 4 — init + check | in progress | — |
 | 5a — per-app DB role | done | `Give each app a Postgres login of its own` |
+| BYO — external database | done | `Let an app bring the database it already has` |
 | 5b — control plane off the shared instance | **not started** | — |
 | 5c — code key out of the spec | done | `Stop shipping the bundle key in the spec that hides it` |
 | 6 — release phase | done | `Run migrations once, before traffic` |
@@ -960,3 +971,41 @@ left that a deploy accepts and does not act on.
 - The **per-app Postgres role is best-effort**: it falls back to the shared
   superuser credential and says so. Every fallback is a tenant boundary that did
   not get created, so those log lines are worth watching on the first real deploys.
+
+### Bring-your-own database — what landed, and what it left
+
+The refusal was one function, and it was why an app with infrastructure of its own
+could not deploy at all. It is now a function of what the deploy will DO rather
+than of how a name is spelled: `PORT` and `SUPERSONIC_*` are always ours, and the
+seventeen database names are ours only while we provision the database that gives
+them meaning.
+
+What this closed beyond the feature: `platformOwned` had a **second reader**.
+`envfile.js:29` kept its own hard-coded copy of the list, so the CLI would have
+stripped the user's `DATABASE_URL` on the way up and the deploy would have failed
+on a variable they had in fact set — the one-rule-many-readers defect this plan is
+named after, reproduced inside the fix for it. The CLI now injects the control
+plane's own predicate; only the bucket and project names stay local, because
+nothing an app declares changes who supplies those.
+
+`missingSecrets` was likewise enforced in exactly one place — `supersonic check`,
+on the user's machine — so the rule the schema calls ENFORCED was skippable by not
+running the tool. An external database's URL is now checked server-side, against
+Secret Manager as well as this deploy's upload, before anything is provisioned or
+built.
+
+Still open:
+
+- **`provisionStorage` runs unconditionally** (`deploy-pipeline.ts:1295`).
+  `resources.bucket` and `uses: ["bucket"]` are both parsed and neither gates it,
+  so every non-static app gets a bucket and `STORAGE_BUCKET` whether it asked or
+  not. The same subtraction as the database, not yet made.
+- **No static egress IP.** Cloud Run reaches the public internet by default, so
+  Supabase and Neon work with no VPC — but a provider that IP-allowlists needs a
+  VPC connector plus Cloud NAT, and the docs recommend a connector over Direct VPC
+  egress there because Direct VPC with Cloud NAT pushes cold start past 30s.
+- **Connection pooling is the user's problem and must be documented as one.**
+  Direct connections exhaust under Cloud Run scale-out; the pooler URL is the one
+  to set.
+- **Nothing verifies the URL before the app does.** The deploy proves the secret
+  reached the revision, not that anything answers at the other end.

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -592,7 +592,36 @@ async function collectEnv(slug, args) {
   if (!Object.keys(local).length) return none;
   let existingKeys = [];
   try { existingKeys = (await api(`/api/apps/${slug}/env`)).keys || []; } catch { /* no service yet */ }
-  return selectEnv(local, { existingKeys });
+  return selectEnv(local, { existingKeys, platformOwned: ownedHere() });
+}
+
+/**
+ * Which names THIS repo's deploy will write for itself.
+ *
+ * Asked of the control plane's own resolver rather than answered here, because it
+ * is not a property of the name: DATABASE_URL belongs to the platform when the
+ * platform provisions the database and to the app when the app already has one.
+ * Answering it locally from a hard-coded list is what made the CLI strip the one
+ * variable a bring-your-own-database deploy cannot run without.
+ *
+ * Undefined on any failure — no config, a malformed one, a build with no bundled
+ * resolver — which leaves `selectEnv` on its own conservative set. A variable
+ * wrongly skipped is printed to the user with a reason; a variable wrongly sent
+ * points a live app at a laptop.
+ */
+function ownedHere() {
+  try {
+    const { resolver } = require("./lib/resolver");
+    const r = resolver();
+    const config = r.readAppConfig(process.cwd());
+    if (!config) return undefined;
+    // Already OR'd with every service's `uses`/`needsDB` by parseAppConfig, so
+    // this is the same answer the server will reach.
+    const database = config.resources && config.resources.database;
+    return (name) => r.platformOwned(name, database);
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/cli/lib/check.js
+++ b/packages/cli/lib/check.js
@@ -144,8 +144,14 @@ function renderCheck(configFilename, app, problems, warnings) {
 
   if (app) {
     const n = app.services.length;
+    // "provisions postgres" for a database the deploy will not create is the same
+    // class of lie as printing a config filename for an inferred app — it sends
+    // someone looking for an instance that is not there, and it hides the one
+    // thing they need to have set.
+    const db = app.resources.database;
+    const external = db && db.provider === "external" ? db : null;
     const provisioned = [
-      app.resources.database ? "postgres" : null,
+      db && !external ? "postgres" : null,
       app.resources.bucket ? "bucket" : null,
     ].filter(Boolean);
     // Which of the two sources this came from, always. "Plan ready:
@@ -154,7 +160,8 @@ function renderCheck(configFilename, app, problems, warnings) {
     const from = app.source === "config"
       ? configFilename
       : `inferred — there is no ${configFilename} (\`supersonic init\` writes one)`;
-    lines.push(`${from} — ${n} service${n === 1 ? "" : "s"}${provisioned.length ? `, provisions ${provisioned.join(" + ")}` : ""}`);
+    const yours = external ? `, uses your own ${external.engine || "database"} from ${external.urlFrom}` : "";
+    lines.push(`${from} — ${n} service${n === 1 ? "" : "s"}${provisioned.length ? `, provisions ${provisioned.join(" + ")}` : ""}${yours}`);
     lines.push("");
     for (const s of app.services) lines.push(...renderService(s), "");
   }

--- a/packages/cli/lib/draft.js
+++ b/packages/cli/lib/draft.js
@@ -284,6 +284,15 @@ function usesFor(service) {
 async function buildDraft(repoDir, { resolver: r, detect }) {
   const { config, stacks } = await draftServices(repoDir, r, detect);
   const candidates = new Map();
+  // Decided over ALL services before any one of them is scanned, because whether
+  // DATABASE_URL is a secret the author must supply or a value the platform writes
+  // depends on it — and a draft that offers DATABASE_URL as a secret for an app
+  // about to be handed a provisioned Postgres is asking the author for something
+  // they must not answer. Same ordering the parser needs, for the same reason.
+  const draftDatabase = config.services.some((s) => usesFor(s).length > 0)
+    ? { provider: "managed", engine: "postgres" }
+    : undefined;
+  const ownedInDraft = (name) => r.platformOwned(name, draftDatabase);
   let wantsDatabase = false;
 
   const services = config.services.map((s) => {
@@ -291,7 +300,7 @@ async function buildDraft(repoDir, { resolver: r, detect }) {
     const absDir = dir === "." ? repoDir : path.join(repoDir, dir);
     const stack = stacks.get(dir);
     const isStatic = s.language === "static";
-    const env = envNames(absDir, { platformOwned: r.platformOwned });
+    const env = envNames(absDir, { platformOwned: ownedInDraft });
     candidates.set(s.name, env);
     wantsDatabase = wantsDatabase || usesFor(s).length > 0;
 

--- a/packages/cli/lib/envfile.js
+++ b/packages/cli/lib/envfile.js
@@ -24,8 +24,24 @@ const path = require("node:path");
 // packageFolder), because a value baked into an image cannot be rotated.
 const ENV_FILES = [".env", ".env.production", ".env.local", ".env.production.local"];
 
-// Set by the platform on every deploy — a local value would overwrite the real one and
-// point the app at a database that does not exist in production.
+// Written by the deploy itself and not by anything the app declares: the bucket it
+// provisions and the project it runs in. Unconditional, because nothing in a config
+// can change who supplies them.
+const ALWAYS_SKIPPED = new Set(["STORAGE_BUCKET", "GOOGLE_CLOUD_PROJECT"]);
+
+/**
+ * The set this file used to own outright, kept as the fallback.
+ *
+ * It was the second reader of a rule the control plane already had, and the two
+ * drifted the way two copies always do — this one listed 6 names against the 17
+ * `databaseEnv()` writes. Worse than the drift is that the rule stopped being true:
+ * whether DATABASE_URL belongs to the platform depends on whether the platform
+ * provisions the database, and this file cannot know that on its own. So callers
+ * that can resolve `supersonic.json` pass the real predicate in, and this remains
+ * only for the ones that cannot — where over-refusing is the safe direction, since
+ * a skipped variable is reported to the user and a wrongly-sent one silently
+ * points a live app at a laptop.
+ */
 const PLATFORM_OWNED = new Set([
   "DATABASE_URL",
   "STORAGE_BUCKET",
@@ -101,14 +117,22 @@ function readEnvFiles(cwd, files = ENV_FILES) {
  * value in production is the one the user set deliberately, and the one in `.env` is
  * very often a test key. Overwriting a live Stripe key with `sk_test_…` on an unrelated
  * redeploy breaks payments silently, which is the worst way for this to fail.
+ *
+ * `platformOwned` is the control plane's own predicate, injected rather than
+ * reimplemented — the same reason `draft.js` takes it. It has to be injected because
+ * the answer is no longer a property of the NAME: an app that declares
+ * `"provider": "external"` owns DATABASE_URL, and this file dropping it as "set by
+ * Supersonic" would strip the one value that deploy cannot run without, before the
+ * server ever sees it. The failure would then arrive as a crash loop about a
+ * variable the user had, in fact, set.
  */
-function selectEnv(vars, { existingKeys = [] } = {}) {
+function selectEnv(vars, { existingKeys = [], platformOwned = (k) => PLATFORM_OWNED.has(k) } = {}) {
   const have = new Set(existingKeys);
   const send = {};
   const skipped = [];
   for (const [key, value] of Object.entries(vars)) {
     if (!value) { skipped.push({ key, reason: "empty" }); continue; }
-    if (PLATFORM_OWNED.has(key)) { skipped.push({ key, reason: "set by Supersonic" }); continue; }
+    if (ALWAYS_SKIPPED.has(key) || platformOwned(key)) { skipped.push({ key, reason: "set by Supersonic" }); continue; }
     if (LOCAL_HOSTS.some((h) => value.includes(h))) { skipped.push({ key, reason: "points at your machine" }); continue; }
     if (have.has(key)) { skipped.push({ key, reason: "already set on the app" }); continue; }
     send[key] = value;
@@ -131,4 +155,4 @@ function encodeEnvHeader(send) {
   return Buffer.byteLength(encoded) > MAX_HEADER_BYTES ? null : encoded;
 }
 
-module.exports = { parseEnv, readEnvFiles, selectEnv, encodeEnvHeader, ENV_FILES, PLATFORM_OWNED, MAX_HEADER_BYTES };
+module.exports = { parseEnv, readEnvFiles, selectEnv, encodeEnvHeader, ENV_FILES, PLATFORM_OWNED, ALWAYS_SKIPPED, MAX_HEADER_BYTES };

--- a/packages/cli/test/check.test.js
+++ b/packages/cli/test/check.test.js
@@ -51,7 +51,7 @@ test("a correct config passes with nothing to say", async () => {
   assert.equal(app.services.length, 2);
   // Resources are once per app: the sibling asked for a database and the primary
   // did not, and the app still provisions one.
-  assert.deepEqual(app.resources.database, { engine: "postgres" });
+  assert.deepEqual(app.resources.database, { provider: "managed", engine: "postgres" });
 });
 
 test("each phase is printed as it would actually run", async () => {

--- a/packages/cli/test/draft.test.js
+++ b/packages/cli/test/draft.test.js
@@ -96,12 +96,23 @@ test("env names are found in both languages and in every spelling", () => {
   assert.deepEqual(buildEnv, ["VITE_URL"]);
 });
 
+const MANAGED_DB = { provider: "managed", engine: "postgres" };
+
 test("names the platform writes are never offered as secrets", () => {
   // Offering one would produce a config parseAppConfig refuses outright — a draft
   // that cannot be parsed is worse than no draft.
   const dir = tree({ "a.js": "process.env.DATABASE_URL; process.env.PORT; process.env.PGHOST; process.env.NODE_ENV; process.env.REAL_KEY;" });
-  const { secrets } = envNames(dir, { platformOwned: r.platformOwned });
+  const { secrets } = envNames(dir, { platformOwned: (n) => r.platformOwned(n, MANAGED_DB) });
   assert.deepEqual(secrets, ["REAL_KEY"]);
+});
+
+test("an app with no database of ours keeps the connection names as its own", () => {
+  // The other half of the same rule. Nothing is provisioned, so nothing writes
+  // these, so they are ordinary secrets the author has to supply — and a draft
+  // that hid them would be hiding the variables the app cannot start without.
+  const dir = tree({ "a.js": "process.env.DATABASE_URL; process.env.PORT; process.env.REAL_KEY;" });
+  const { secrets } = envNames(dir, { platformOwned: (n) => r.platformOwned(n, undefined) });
+  assert.deepEqual(secrets, ["DATABASE_URL", "REAL_KEY"]);
 });
 
 test("somebody else's dependencies are not this app's environment", () => {

--- a/packages/cli/test/envfile.test.js
+++ b/packages/cli/test/envfile.test.js
@@ -79,6 +79,30 @@ test("vars the platform sets itself are never taken from .env", () => {
   assert.deepEqual(skipped.map((s) => s.key).sort(), ["DATABASE_URL", "PORT"]);
 });
 
+test("an app that owns its database keeps its own connection URL", () => {
+  // The bug this closes: the rule "DATABASE_URL is set by Supersonic" lived here
+  // as a hard-coded name, so a repo declaring `"provider": "external"` had the one
+  // value its deploy cannot run without stripped on the way up — and the failure
+  // arrived as a crash loop about a variable the user had set.
+  const owned = (k) => k === "PORT";
+  const { send, skipped } = selectEnv(
+    { DATABASE_URL: "postgres://user:pw@db.supabase.co:6543/postgres", PORT: "3000" },
+    { platformOwned: owned },
+  );
+  assert.deepEqual(send, { DATABASE_URL: "postgres://user:pw@db.supabase.co:6543/postgres" });
+  assert.deepEqual(skipped.map((s) => s.key), ["PORT"]);
+});
+
+test("the bucket and project are skipped whatever the predicate says", () => {
+  // Not part of the injected rule: nothing an app declares changes who provisions
+  // its bucket or which project it runs in.
+  const { send } = selectEnv(
+    { STORAGE_BUCKET: "mine", GOOGLE_CLOUD_PROJECT: "mine", KEEP: "yes" },
+    { platformOwned: () => false },
+  );
+  assert.deepEqual(send, { KEEP: "yes" });
+});
+
 test("anything aimed at the developer's own machine is left behind", () => {
   const { send } = selectEnv({
     REDIS_URL: "redis://127.0.0.1:6379",

--- a/packages/cli/vendor/resolve.js
+++ b/packages/cli/vendor/resolve.js
@@ -1,4 +1,4 @@
-// supersonic-vendor-stamp 8f1eb85c8b742804
+// supersonic-vendor-stamp bf07a407c4ecd39c
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
@@ -104,10 +104,14 @@ var CONFIG_FILENAME = "supersonic.json";
 var ConfigError = class extends Error {
 };
 var LANGUAGES = /* @__PURE__ */ new Set(["node", "python", "static", "other"]);
-var PLATFORM_OWNED_PREFIXES = [/^POSTGRES_/, /^PG/, /^DB_/, /^SUPERSONIC_/];
-var PLATFORM_OWNED_EXACT = /* @__PURE__ */ new Set([...databaseEnvNames(), "PORT"]);
-function platformOwned(name) {
-  return PLATFORM_OWNED_EXACT.has(name) || PLATFORM_OWNED_PREFIXES.some((re) => re.test(name));
+var ALWAYS_OWNED_PREFIXES = [/^SUPERSONIC_/];
+var ALWAYS_OWNED_EXACT = /* @__PURE__ */ new Set(["PORT"]);
+var DATABASE_OWNED_PREFIXES = [/^POSTGRES_/, /^PG/, /^DB_/];
+var DATABASE_OWNED_EXACT = new Set(databaseEnvNames());
+function platformOwned(name, database) {
+  if (ALWAYS_OWNED_EXACT.has(name) || ALWAYS_OWNED_PREFIXES.some((re) => re.test(name))) return true;
+  if (database?.provider !== "managed") return false;
+  return DATABASE_OWNED_EXACT.has(name) || DATABASE_OWNED_PREFIXES.some((re) => re.test(name));
 }
 function safeDir(dir, where) {
   if (dir === void 0 || dir === null || dir === "") return ".";
@@ -129,16 +133,16 @@ function num(v, where) {
   if (typeof v !== "number" || !Number.isFinite(v)) throw new ConfigError(`${where} must be a number`);
   return v;
 }
-function literals(v, where) {
+function literals(v, where, database) {
   if (v === void 0 || v === null) return void 0;
   if (typeof v !== "object" || Array.isArray(v)) {
     throw new ConfigError(`${where} must be an object of NAME: value, or an array of variable NAMES`);
   }
   const out = {};
   for (const [k, raw] of Object.entries(v)) {
-    if (platformOwned(k)) {
+    if (platformOwned(k, database)) {
       throw new ConfigError(
-        `${where}: "${k}" is set by the platform and cannot be declared here. Remove it \u2014 the value the app receives is the one the platform provisions.`
+        `${where}: "${k}" is set by the platform and cannot be declared here. ` + ownedBecause(k, database)
       );
     }
     if (typeof raw !== "string" && typeof raw !== "number" && typeof raw !== "boolean") {
@@ -148,14 +152,20 @@ function literals(v, where) {
   }
   return out;
 }
-function names(v, where) {
+function ownedBecause(name, database) {
+  if (ALWAYS_OWNED_EXACT.has(name) || ALWAYS_OWNED_PREFIXES.some((re) => re.test(name))) {
+    return name === "PORT" ? `Cloud Run assigns the port and injects it \u2014 read it from the environment instead.` : `SUPERSONIC_* is the platform's own namespace.`;
+  }
+  return `The platform provisions this app's database, so it writes this value itself. If the app already HAS a database, declare it instead: "resources": { "database": { "provider": "external", "urlFrom": "${name}" } }`;
+}
+function names(v, where, database) {
   if (v === void 0 || v === null) return void 0;
   if (!Array.isArray(v) || v.some((e) => typeof e !== "string")) {
     throw new ConfigError(`${where} must be an array of variable NAMES`);
   }
   for (const n of v) {
-    if (platformOwned(n)) {
-      throw new ConfigError(`${where}: "${n}" is set by the platform and cannot be declared here.`);
+    if (platformOwned(n, database)) {
+      throw new ConfigError(`${where}: "${n}" is set by the platform and cannot be declared here. ` + ownedBecause(n, database));
     }
   }
   return v;
@@ -198,9 +208,32 @@ function resources(v) {
       throw new ConfigError(`${where}.database must be an object`);
     }
     const d = o.database;
-    const engine = str(d.engine, `${where}.database.engine`) ?? "postgres";
-    if (engine !== "postgres") throw new ConfigError(`${where}.database.engine: only "postgres" is provisioned today (got ${JSON.stringify(engine)})`);
-    database = { engine: "postgres", version: str(d.version, `${where}.database.version`) };
+    const provider = str(d.provider, `${where}.database.provider`) ?? "managed";
+    if (provider !== "managed" && provider !== "external") {
+      throw new ConfigError(
+        `${where}.database.provider must be "managed" (the platform creates it) or "external" (it already exists and the platform only injects it) \u2014 got ${JSON.stringify(provider)}`
+      );
+    }
+    if (provider === "external") {
+      const urlFrom = str(d.urlFrom, `${where}.database.urlFrom`)?.trim();
+      if (!urlFrom) {
+        throw new ConfigError(
+          `${where}.database: an external database needs "urlFrom" \u2014 the NAME of the secret holding its connection URL, for example "DATABASE_URL". The value itself belongs in your .env or in \`supersonic env set\`, never in this file.`
+        );
+      }
+      if (platformOwned(urlFrom)) {
+        throw new ConfigError(`${where}.database.urlFrom: "${urlFrom}" is set by the platform and cannot hold your connection URL.`);
+      }
+      database = { provider: "external", engine: str(d.engine, `${where}.database.engine`), urlFrom };
+    } else {
+      const engine = str(d.engine, `${where}.database.engine`) ?? "postgres";
+      if (engine !== "postgres") {
+        throw new ConfigError(
+          `${where}.database.engine: only "postgres" is provisioned today (got ${JSON.stringify(engine)}). An ${engine} the app already has can be declared with "provider": "external".`
+        );
+      }
+      database = { provider: "managed", engine: "postgres", version: str(d.version, `${where}.database.version`) };
+    }
   }
   return { database, bucket: o.bucket === void 0 ? void 0 : Boolean(o.bucket) };
 }
@@ -216,6 +249,8 @@ function parseAppConfig(text) {
   if (!Array.isArray(o.services) || o.services.length === 0) {
     throw new ConfigError(`${CONFIG_FILENAME} needs a non-empty "services" array`);
   }
+  const declaredResources = resources(o.resources);
+  const database = declaredDatabase(declaredResources, o.services);
   const services = o.services.map((s, i) => {
     const where = `${CONFIG_FILENAME} services[${i}]`;
     if (!s || typeof s !== "object" || Array.isArray(s)) throw new ConfigError(`${where} must be an object`);
@@ -225,7 +260,7 @@ function parseAppConfig(text) {
       throw new ConfigError(`${where}.language must be one of ${[...LANGUAGES].join(", ")}`);
     }
     const envIsNameList = Array.isArray(svc.env);
-    const uses = svc.uses === void 0 ? void 0 : names(svc.uses, `${where}.uses`);
+    const uses = svc.uses === void 0 ? void 0 : names(svc.uses, `${where}.uses`, database);
     for (const u of uses ?? []) {
       if (u !== "database" && u !== "bucket") {
         throw new ConfigError(`${where}.uses: "${u}" is not a resource \u2014 expected "database" or "bucket"`);
@@ -248,10 +283,10 @@ function parseAppConfig(text) {
       context: svc.context === void 0 ? void 0 : safeDir(svc.context, `${where}.context`),
       needsDB: svc.needsDB === void 0 ? void 0 : Boolean(svc.needsDB),
       uses,
-      env: envIsNameList ? void 0 : literals(svc.env, `${where}.env`),
-      envNeeded: envIsNameList ? names(svc.env, `${where}.env`) : void 0,
-      buildEnv: literals(svc.buildEnv, `${where}.buildEnv`),
-      secrets: names(svc.secrets, `${where}.secrets`),
+      env: envIsNameList ? void 0 : literals(svc.env, `${where}.env`, database),
+      envNeeded: envIsNameList ? names(svc.env, `${where}.env`, database) : void 0,
+      buildEnv: literals(svc.buildEnv, `${where}.buildEnv`, database),
+      secrets: names(svc.secrets, `${where}.secrets`, database),
       health: health(svc.health, `${where}.health`),
       scale: scale(svc.scale, `${where}.scale`),
       path: str(svc.path, `${where}.path`)
@@ -272,14 +307,23 @@ function parseAppConfig(text) {
   }
   return {
     version: typeof o.version === "number" ? o.version : 1,
-    resources: appResources(resources(o.resources), services),
+    resources: appResources(declaredResources, services),
     services
   };
+}
+function declaredDatabase(declared, rawServices) {
+  if (declared?.database) return declared.database;
+  const wants = rawServices.some((s) => {
+    if (!s || typeof s !== "object" || Array.isArray(s)) return false;
+    const svc = s;
+    return Boolean(svc.needsDB) || Array.isArray(svc.uses) && svc.uses.includes("database");
+  });
+  return wants ? { provider: "managed", engine: "postgres" } : void 0;
 }
 function appResources(declared, services) {
   const wantsDb = services.some(usesDatabase);
   const wantsBucket = services.some((s) => (s.uses ?? []).includes("bucket"));
-  const database = declared?.database ?? (wantsDb ? { engine: "postgres" } : void 0);
+  const database = declared?.database ?? (wantsDb ? { provider: "managed", engine: "postgres" } : void 0);
   const bucket = declared?.bucket ?? (wantsBucket ? true : void 0);
   if (!database && bucket === void 0) return declared;
   return { database, bucket };
@@ -698,6 +742,8 @@ function validate(app, dir) {
 function missingSecrets(app, available) {
   const have = new Set(available);
   const want = new Set(app.services.flatMap((s) => s.secrets));
+  const db = app.resources.database;
+  if (db?.provider === "external") want.add(db.urlFrom);
   return [...want].filter((n) => !have.has(n)).sort();
 }
 


### PR DESCRIPTION
`resources.database` was a boolean in disguise — present meant PROVISION — so there was nowhere to say "there is a database and it is not yours". That excluded every app with infrastructure of its own.

```json
"resources": { "database": { "provider": "external", "engine": "postgres", "urlFrom": "DATABASE_URL" } }
```

`provider` defaults to `"managed"`, so every existing config means exactly what it meant.

## What changed

- **`platformOwned` turns on fact, not spelling.** `PORT` and `SUPERSONIC_*` are always ours; the 17 names `databaseEnv()` writes are ours only while we provision the database. The set is still derived from `databaseEnv()` so it cannot drift, and the refusal now names the line to write.
- **`parseAppConfig` resolves `resources` before validating services**, since `uses: ["database"]` feeds the same decision.
- **The CLI stops stripping the user's `DATABASE_URL`.** `envfile.js` kept its own hard-coded copy of the owned-names list — the one-rule-many-readers defect this plan is named after, reproduced inside the fix for it. It now injects the control plane's predicate.
- **`missingSecrets` is enforced server-side**, against Secret Manager as well as this deploy's upload. It was previously only enforced by `supersonic check`, on the user's machine.
- **`assertReached` checks the right evidence per mode** — provisioning ran for managed, the secret is mounted by reference for external.

An external database gets no proxy sidecar, so it skips `--depends-on`, the mandatory startup probe and the container-scoped argv entirely.

## Verification

565 web tests, 93 CLI tests, `tsc --noEmit` clean.

Verified against the live API with `gcloud run services replace --dry-run` (applies nothing):

- the secret-vs-plain collision that is documented nowhere **is** caught — `Secret environment variable overlaps non secret environment variable`
- a secret reference to a secret that does not exist is **not** caught — validation checks shape, not resolvability, which is the gap the server-side check fills

## Still open

Written into `docs/DEPLOY-PLAN.md` rather than left implied: `provisionStorage` runs unconditionally; no static egress IP for allowlisting providers; pooling is the user's problem and needs documenting; nothing proves anything answers at the other end of the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for externally hosted databases using a configured connection secret.
  * Managed PostgreSQL databases continue to be provisioned automatically.
  * Deployment plans now show database provider, engine, and connection source details.
  * Database usage can be inferred when services request database access.

* **Bug Fixes**
  * Deployments now fail early with clear guidance when required external database secrets are missing.
  * Environment variables are filtered according to whether database connectivity is platform-managed or externally supplied.
  * Added validation for database providers, engines, and external secret references.

* **Documentation**
  * Updated deployment documentation with external database configuration and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->