### PR TITLE
A push to the branch ships the app

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,6 +57,14 @@ connections and one workspace.
 _Avoid_: integration, link, OAuth connection, GitHub account, token.
 Product language says *connected account*.
 
+**Connected repository**:
+The link between one **App** and one branch of one repository on GitHub. Its
+existence is what makes a `git push` a **Ship**: without it a repository is a
+URL somebody typed once, and with it every push to that branch is a **Build**.
+One app, one connected repository — a second repository is a second app.
+Product language says *your GitHub*.
+_Avoid_: integration, git provider, source control, repo link, auto deploy.
+
 **Deploy target**:
 Where an app's processes end up running. Today there are two — the **Fleet**, and
 Cloud Run. Naming the concept is what makes "which one" a decision rather than
@@ -163,6 +171,7 @@ it in the meantime.
 - An **App** may have a **Shadow**
 - An **App** may have any number of **Attached domains**; each belongs to one app
 - A workspace may hold any number of **Connections**; each belongs to one workspace
+- An **App** may follow one **Connected repository**; a push to its branch is a **Build**
 - An **App** deployed from a private repository names the **Connection** it came through
 
 ## Resolved ambiguities

--- a/apps/web/app/api/apps/[slug]/git/route.ts
+++ b/apps/web/app/api/apps/[slug]/git/route.ts
@@ -1,0 +1,94 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { getAppBySlug } from "@/lib/apps";
+import { currentUserId } from "@/lib/session";
+import { repoForSlug, setBranch, setAutoDeploy, unlinkRepo } from "@/lib/app-repos";
+
+/**
+ * One app's connected repository: read it, change which branch it follows,
+ * turn automatic shipping off, or disconnect it.
+ *
+ * Owner-only, asked of the app row, following
+ * `app/api/apps/[slug]/domains/route.ts`. The installation was already checked
+ * against the workspace when the link was written; what this route guards is
+ * narrower and simpler — only the app's owner may change what its own app
+ * follows.
+ */
+async function ownedApp(slug: string) {
+  const uid = await currentUserId();
+  if (!uid) return null;
+  const app = await getAppBySlug(slug);
+  if (!app || app.owner_id !== uid) return null;
+  return app;
+}
+
+/**
+ * What the panel draws, and nothing else.
+ *
+ * `installationId` is deliberately absent. It is ours, it means nothing to the
+ * person, and a field a page does not use is a field that leaks the day
+ * somebody logs the payload — the same rule the domains route states about
+ * `cert_id`.
+ */
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const slug = decodeURIComponent(params.slug);
+  if (!(await ownedApp(slug))) return Response.json({ error: "not found" }, { status: 404 });
+  const link = await repoForSlug(slug);
+  // `connected: false` rather than a 404: "this app has no repository" is a
+  // normal state with its own screen, not a missing resource.
+  if (!link) return Response.json({ connected: false });
+  return Response.json({
+    connected: true,
+    repo: link.repoFullName,
+    branch: link.branch,
+    autoDeploy: link.autoDeploy,
+    connectedAt: link.connectedAt,
+    url: `https://github.com/${link.repoFullName}`,
+  });
+}
+
+/**
+ * Change the branch, the switch, or both.
+ *
+ * A branch is not validated against GitHub here. It could be — one request —
+ * and it would refuse a branch that does not exist YET, which is a normal thing
+ * to set up before pushing it. A branch nobody pushes is a connection that
+ * simply never fires, and that is visible in the app's timeline; a refusal
+ * would be a wrong answer that costs a person their afternoon.
+ */
+export async function PUT(req: Request, { params }: { params: { slug: string } }) {
+  const slug = decodeURIComponent(params.slug);
+  if (!(await ownedApp(slug))) return Response.json({ error: "not found" }, { status: 404 });
+  if (!(await repoForSlug(slug))) return Response.json({ error: "no repository is connected" }, { status: 409 });
+
+  const body = (await req.json().catch(() => ({}))) as { branch?: unknown; autoDeploy?: unknown };
+
+  if (typeof body.branch === "string") {
+    const branch = body.branch.trim();
+    // Git's own rules, reduced to what a branch name can never contain. A name
+    // that git would refuse must not reach the column a push is matched on,
+    // where it would simply never match and look like a broken integration.
+    if (!branch || branch.length > 255 || /[\s~^:?*\[\\]/.test(branch) || branch.includes("..")) {
+      return Response.json({ error: "that is not a branch name" }, { status: 400 });
+    }
+    await setBranch(slug, branch);
+  }
+
+  if (typeof body.autoDeploy === "boolean") await setAutoDeploy(slug, body.autoDeploy);
+
+  const link = await repoForSlug(slug);
+  return Response.json({ connected: true, repo: link?.repoFullName, branch: link?.branch, autoDeploy: link?.autoDeploy });
+}
+
+/**
+ * Disconnect. The app keeps running and keeps its `repo_url`, so it can still
+ * be rebuilt from the same repository by hand — what stops is the automatic
+ * part, which is the only thing this row ever controlled.
+ */
+export async function DELETE(_req: Request, { params }: { params: { slug: string } }) {
+  const slug = decodeURIComponent(params.slug);
+  if (!(await ownedApp(slug))) return Response.json({ error: "not found" }, { status: 404 });
+  await unlinkRepo(slug);
+  return Response.json({ connected: false });
+}

--- a/apps/web/app/api/deploy/route.ts
+++ b/apps/web/app/api/deploy/route.ts
@@ -14,6 +14,9 @@ import { createRun, startDeployRun, finishRun, pruneRuns, isOwnSourceObject, rea
 import { readEvents, pruneEvents } from "@/lib/deploy-events";
 import { getDeploy } from "@/lib/deploys";
 import { startBuild, finishBuild } from "@/lib/builds";
+import { fullNameFromUrl, repoFor } from "@/lib/github-repos";
+import { branchHead } from "@/lib/github-status";
+import type { RepoLink } from "@/lib/app-repos";
 import { StageRecorder } from "@/lib/stages";
 import { randomUUID } from "node:crypto";
 
@@ -173,6 +176,8 @@ export async function POST(req: Request) {
    * an uploaded folder has no repository and therefore no grant.
    */
   let ghInstallationId: number | null = null;
+  /** The branch the GitHub door asked to follow, before it is resolved. */
+  let connectBranch = "";
   let reservedSlug = "";
   // The production run command the deploying agent worked out for this app (e.g.
   // `uvicorn main:app --host 0.0.0.0 --port $PORT`, `next start`). It's the reliable
@@ -222,6 +227,10 @@ export async function POST(req: Request) {
     const rawInstall = String(body.installationId ?? "").trim();
     ghInstallationId = /^\d+$/.test(rawInstall) && Number.isSafeInteger(Number(rawInstall))
       ? Number(rawInstall) : null;
+    // The branch this app should FOLLOW from now on. Named only by the GitHub
+    // door; empty means "the repository's default", which the door usually
+    // prefills but a bare API caller will not.
+    connectBranch = String(body.connectBranch ?? "").trim();
   }
   // Apps get a short random subdomain (e.g. as76d.supersonic.cv). A reserved slug
   // (URL-first / tunnel deploys) is honoured so the build lands on the URL already
@@ -262,9 +271,40 @@ export async function POST(req: Request) {
   }
 
 
+  // The connection, resolved against GitHub rather than against the request.
+  //
+  // Two things come out of one place on purpose: the repository's real id — a
+  // fact, not the client's claim, see `repoFor` — and the commit the branch
+  // points at right now. Both are needed before the run row is written, and
+  // both are optional in the sense that failing to get either leaves the deploy
+  // exactly as it was before any of this existed: an unpinned clone with no
+  // link written.
+  let connect: RepoLink | null = null;
+  let commitSha: string | null = null;
+  if (!isUpload && ghInstallationId !== null && ownerWorkspace) {
+    const fullName = fullNameFromUrl(url);
+    if (fullName) {
+      try {
+        const repo = await repoFor(ghInstallationId, fullName);
+        if (repo) {
+          const branch = connectBranch || repo.defaultBranch;
+          connect = { installationId: ghInstallationId, repoId: repo.id, repoFullName: repo.fullName, branch };
+          // Pinned so the FIRST build reports on a commit like every later one.
+          // Null here is not a failure — it is the clone this door has always
+          // made, of whatever the branch points at when the builder starts.
+          commitSha = await branchHead(ghInstallationId, repo.fullName, branch);
+        }
+      } catch {
+        // A GitHub that will not answer must not stop a deploy that can
+        // otherwise proceed. The app still builds; it simply does not become
+        // automatic, and the panel can connect it afterwards.
+      }
+    }
+  }
+
   const input = {
     ownerId, ownerWorkspace, slug, friendlyName, repoUrl: url,
-    ghInstallationId, isUpload, isPrebuilt, prebuiltHash, secrets, cloneToken, runCmd, limits,
+    ghInstallationId, commitSha, connect, isUpload, isPrebuilt, prebuiltHash, secrets, cloneToken, runCmd, limits,
   };
 
   // Hand the deploy to a job and stream back its event log. The request stops

--- a/apps/web/app/api/github/setup/route.ts
+++ b/apps/web/app/api/github/setup/route.ts
@@ -55,6 +55,12 @@ export async function GET(req: Request): Promise<Response> {
       accountLogin: account.login,
       accountType: account.type,
       connectedBy: userId,
+      // Only for a personal installation, where the account IS the person who
+      // installed it. GitHub does not say which member installed an
+      // organisation's App, so an org records null and every push through it
+      // answers `someone` — see `whoPushed` in lib/github-deploy.ts, and
+      // CONTEXT.md on why a wrong name there is worse than no name.
+      connectedLogin: account.type === "User" ? account.login : null,
     });
     return back(req, { connected: account.login });
   } catch (e) {

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -1,0 +1,88 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { verifySignature, webhookConfigured, readPush } from "@/lib/github-webhook";
+import { forgetInstallation } from "@/lib/github-connections";
+import { shipPush } from "@/lib/github-deploy";
+
+/**
+ * Where GitHub tells us somebody pushed.
+ *
+ * ## The one security boundary
+ *
+ * This route is exempt from the cookie gate in `auth.config.ts`, beside
+ * Stripe's. There is no session behind it and no second check further in, and
+ * what sits behind it can clone a private repository, run a container and
+ * deploy to a live address under our own service account. The HMAC is the whole
+ * boundary — which is why the body is read as TEXT first and parsed second, and
+ * why nothing above the signature check touches the database.
+ *
+ * ## Why almost everything answers 200
+ *
+ * A delivery that did nothing is not an error. GitHub sends a push for a tag,
+ * for a branch being deleted, for repositories nobody connected, and for events
+ * we did not ask for — and the *Advanced* tab on the App page shows the
+ * response body for every one of them. `{"ignored": "no-app-follows-this-branch"}`
+ * is the difference between diagnosing this in a minute and reading our logs
+ * for an hour. A non-2xx would also make GitHub retry, which for "nobody cares
+ * about this repository" means retrying forever.
+ *
+ * The exceptions are the two that are genuinely wrong: an unconfigured platform
+ * (503) and a signature that does not verify (401).
+ */
+
+function ignored(reason: string, extra: Record<string, unknown> = {}): Response {
+  return Response.json({ ignored: reason, ...extra });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  if (!webhookConfigured()) {
+    return Response.json({ error: "no GitHub webhook secret configured" }, { status: 503 });
+  }
+
+  // Before JSON.parse, always. Re-serialising the parsed object produces
+  // different bytes and therefore a signature that can never match, for a body
+  // that looks identical in every way a person would check.
+  const raw = await req.text();
+  if (!verifySignature(raw, req.headers.get("x-hub-signature-256"))) {
+    return Response.json({ error: "bad signature" }, { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    // Signed by us and unparseable is a contradiction, so it is dropped rather
+    // than raised: retrying will not fix it and there is nothing to act on.
+    return ignored("unparseable-body");
+  }
+
+  const event = req.headers.get("x-github-event") ?? "";
+
+  if (event === "ping") return Response.json({ ok: true });
+
+  if (event === "installation") {
+    const action = String((payload as { action?: unknown }).action ?? "");
+    const id = Number((payload as { installation?: { id?: unknown } }).installation?.id);
+    if (action === "deleted" && Number.isInteger(id)) {
+      await forgetInstallation(id);
+      return Response.json({ ok: true, forgot: id });
+    }
+    return ignored(`installation.${action || "unknown"}`);
+  }
+
+  // The set of repositories an installation can see changed. Nothing to store:
+  // the picker reads that set live from GitHub for exactly this reason — a
+  // mirror would be a second answer, wrong precisely when somebody is staring
+  // at the list wondering where their new repository is.
+  if (event === "installation_repositories") return ignored("installation_repositories");
+
+  if (event !== "push") return ignored(`unhandled-event:${event || "none"}`);
+
+  const read = readPush(payload);
+  if (!read.ok) return ignored(read.reason);
+
+  const result = await shipPush(read.push);
+  if (!result.shipped) return ignored(result.reason, result.slug ? { slug: result.slug } : {});
+  return Response.json({ ok: true, slug: result.slug, runId: result.runId, sha: read.push.sha });
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -650,6 +650,9 @@ a.shelf-host:hover { color: var(--ink); text-decoration: underline; text-underli
 .gh-repo .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .gh-repo .tag { font-size: 10.5px; letter-spacing: .04em; text-transform: uppercase; color: var(--faint); border: 1px solid var(--line); padding: 2px 6px; border-radius: var(--r); }
 .gh-repo:hover .tag { color: inherit; border-color: currentColor; }
+/* The branch reads as a name rather than a label: it is the one tag on the row
+   whose value is the repository's own word, not ours. */
+.gh-repo .tag.branch { text-transform: none; letter-spacing: 0; }
 .btn.big { height: 42px; padding: 0 20px; font-size: 13px; }
 .deploy-cta .hint { font-size: 11.5px; color: var(--faint); letter-spacing: .04em; text-transform: uppercase; }
 

--- a/apps/web/app/new/page.tsx
+++ b/apps/web/app/new/page.tsx
@@ -380,12 +380,21 @@ export default function NewApp() {
                                 onClick={() => { setRepo(r.fullName); begin(r.fullName); }}
                               >
                                 <span className="name">{r.fullName}</span>
+                                {/* The branch that will ship from now on, said
+                                    here rather than asked for: picking one is a
+                                    second click on the screen whose whole job is
+                                    the first, and it is changeable afterwards in
+                                    the app's own panel. */}
+                                <span className="tag branch">{r.defaultBranch}</span>
                                 {r.private && <span className="tag">private</span>}
                               </button>
                             ))}
                           </div>
                         )}
                         <p className="lead" style={{ margin: "10px 0 0", fontSize: 12, opacity: 0.7 }}>
+                          Every push to that branch ships your app. You can change the branch, or turn it off, any time.
+                        </p>
+                        <p className="lead" style={{ margin: "4px 0 0", fontSize: 12, opacity: 0.7 }}>
                           Not seeing one? <a href={ghLinks?.configureUrl ?? "#"}>Choose which repositories we can see</a>.
                         </p>
                       </>

--- a/apps/web/auth.config.ts
+++ b/apps/web/auth.config.ts
@@ -47,7 +47,12 @@ export const authConfig = {
         (!PROD && (p.startsWith("/design") || p.startsWith("/landing"))) ||
         // Stripe calls this server-to-server with no cookie; it verifies its own
         // signature. The rest of /api/billing stays behind the cookie gate.
-        p.startsWith("/api/billing/webhook");
+        p.startsWith("/api/billing/webhook") ||
+        // GitHub, for the same reason and on the same terms: no cookie exists to
+        // send, and the route verifies an HMAC over the raw body before it
+        // touches anything. The rest of /api/github stays behind the gate —
+        // those routes answer a person, and a person has a session.
+        p.startsWith("/api/github/webhook");
       if (isPublic) return true;
       return !!auth?.user;
     },

--- a/apps/web/components/GitPanel.tsx
+++ b/apps/web/components/GitPanel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Github, Loader2, Check, Unlink } from "lucide-react";
+
+/**
+ * The repository this app follows, from the person's side.
+ *
+ * One claim and one switch. The claim — "every push to this branch ships your
+ * app" — is the whole feature, so it is stated in those words rather than
+ * implied by a checkbox labelled *auto deploy*; a person who reads only this
+ * panel should be able to predict exactly what their next `git push` does.
+ *
+ * Draws nothing at all when no repository is connected. An app deployed from a
+ * folder or a public URL has no connection to show, and an empty card offering
+ * to connect one would be a second, worse copy of the GitHub door on /new — the
+ * connection is made there, where the repositories already are.
+ */
+
+interface Link {
+  connected: boolean;
+  repo?: string;
+  branch?: string;
+  autoDeploy?: boolean;
+  url?: string;
+}
+
+export function GitPanel({ slug, onToast }: { slug: string; onToast: (m: string) => void }) {
+  const [link, setLink] = useState<Link | null>(null);
+  const [branch, setBranch] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const d = (await (await fetch(`/api/apps/${slug}/git`)).json()) as Link;
+      setLink(d);
+      if (d.branch) setBranch(d.branch);
+    } catch {
+      // A page that cannot reach the API shows what it last knew, and shows
+      // nothing on a first load rather than an error about our own network.
+    }
+  }, [slug]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function save(body: Record<string, unknown>, said: string) {
+    setBusy(true); setErr("");
+    try {
+      const res = await fetch(`/api/apps/${slug}/git`, {
+        method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+      });
+      const d = await res.json();
+      if (!res.ok) { setErr(d.error || "That didn't save."); return; }
+      setLink(d); setBranch(d.branch ?? ""); onToast(said);
+    } catch {
+      setErr("That didn't save. Try again in a moment.");
+    } finally { setBusy(false); }
+  }
+
+  async function disconnect() {
+    setBusy(true); setErr("");
+    try {
+      await fetch(`/api/apps/${slug}/git`, { method: "DELETE" });
+      setLink({ connected: false });
+      // Said in full, because the thing that stops is not the thing a person
+      // might fear stopping: the app keeps running and keeps its address.
+      onToast("Disconnected. Your app keeps running — pushes just won't ship it.");
+    } catch {
+      setErr("That didn't save. Try again in a moment.");
+    } finally { setBusy(false); }
+  }
+
+  if (!link?.connected) return null;
+
+  const on = link.autoDeploy !== false;
+  const changed = branch.trim() !== "" && branch.trim() !== link.branch;
+
+  return (
+    <div className="set-card">
+      <div className="set-head">
+        <Github size={15} />
+        <div>
+          <div className="st">Source</div>
+          <div className="ss">Where this app&apos;s code comes from, and what a push to it does.</div>
+        </div>
+      </div>
+      <div className="dom-custom" style={{ borderTop: "none" }}>
+      <div className="dom-item">
+        <Github size={14} />
+        <a className="dom-host mono" href={link.url} target="_blank" rel="noreferrer">{link.repo}</a>
+        {on
+          ? <span className="dom-state ok"><Check size={12} />Ships on push</span>
+          : <span className="dom-state">Paused</span>}
+      </div>
+
+      <div className="dom-add">
+        <input
+          className="in mono"
+          value={branch}
+          disabled={busy}
+          onChange={(e) => setBranch(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter" && changed) void save({ branch: branch.trim() }, `Now shipping from ${branch.trim()}.`); }}
+          placeholder="main"
+          aria-label="Branch"
+        />
+        <button
+          className="btn primary"
+          disabled={busy || !changed}
+          onClick={() => void save({ branch: branch.trim() }, `Now shipping from ${branch.trim()}.`)}
+        >
+          {busy ? <Loader2 size={13} className="spin" /> : null}Change branch
+        </button>
+      </div>
+
+      <p className="dom-note">
+        {on
+          ? <>Every push to <span className="mono">{link.branch}</span> ships this app.</>
+          : <>Pushes to <span className="mono">{link.branch}</span> are ignored until you turn this back on.</>}
+      </p>
+
+      <div className="dom-add">
+        <button
+          className="btn"
+          disabled={busy}
+          onClick={() => void save({ autoDeploy: !on }, on ? "Pushes won't ship this app any more." : "Pushes will ship this app again.")}
+        >{on ? "Pause shipping on push" : "Ship on push again"}</button>
+        <button className="btn" disabled={busy} onClick={() => void disconnect()}>
+          <Unlink size={13} />Disconnect
+        </button>
+      </div>
+
+      {err && <div className="set-err">⚠ {err}</div>}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/SettingsSection.tsx
+++ b/apps/web/components/SettingsSection.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, Trash2, KeyRound, Globe, AlertTriangle, Loader2 } from "lucide-react";
 import { DomainsPanel } from "./DomainsPanel";
+import { GitPanel } from "./GitPanel";
 
 export function SettingsSection({
   slug, name, liveHost, envKeys, onToast,
@@ -95,6 +96,11 @@ export function SettingsSection({
         </div>
         <DomainsPanel slug={slug} onToast={onToast} />
       </div>
+
+      {/* Source. Draws nothing at all when no repository is connected — an app
+          deployed from a folder has no connection to show, and an empty card
+          offering to make one would be a worse copy of the door on /new. */}
+      <GitPanel slug={slug} onToast={onToast} />
 
       {/* Danger zone */}
       <div className="set-card danger">

--- a/apps/web/components/panel/Dev.tsx
+++ b/apps/web/components/panel/Dev.tsx
@@ -12,6 +12,7 @@ import { StoragePanel } from "@/components/StoragePanel";
 import { JobsPanel } from "@/components/JobsPanel";
 import { IssuesPanel } from "@/components/IssuesPanel";
 import { DomainsPanel } from "@/components/DomainsPanel";
+import { GitPanel } from "@/components/GitPanel";
 import SharePanel from "@/components/SharePanel";
 import { readPanel, type Reading } from "@/lib/panel/reading";
 
@@ -248,6 +249,7 @@ function ScreenBody({ d, slug, view }: { d: Reading; slug: string; view: View })
     return (
       <div className="flex flex-col gap-3">
         <SharePanel slug={slug} />
+        <GitPanel onToast={toast} slug={slug} />
         <DomainsPanel onToast={toast} slug={slug} />
       </div>
     );

--- a/apps/web/db/033_app_repos.sql
+++ b/apps/web/db/033_app_repos.sql
@@ -1,0 +1,75 @@
+-- Which repository an app follows, so a push can ship it.
+--
+-- 032 wrote down the CONNECTION — an installation a workspace owns — and that
+-- is what makes a private repository readable. It says nothing about which app
+-- came from which repository, so the platform could clone on request and could
+-- not answer the only question a push asks: "does anybody care about this?"
+--
+-- This is that answer, and it is the whole difference between a repository
+-- somebody typed once and a repository that ships.
+
+CREATE TABLE IF NOT EXISTS app_repos (
+  -- By slug, one row per app, following 031_app_domains.sql — `apps.slug` is
+  -- unique, everything on this platform resolves from a slug, and ON DELETE
+  -- CASCADE stops a deleted app leaving behind a link that pushes still match
+  -- and nothing can clear.
+  --
+  -- PRIMARY KEY rather than an index over a growable set, because one app
+  -- follows one repository. A second repository is a second app.
+  slug            text PRIMARY KEY REFERENCES apps(slug) ON DELETE CASCADE,
+
+  -- Through which grant the clone happens. CASCADE because a connection that is
+  -- gone cannot read anything: leaving the row would leave an app that looks
+  -- connected and fails at `git fetch` with a credential error, which is the
+  -- least legible failure this feature has.
+  installation_id bigint NOT NULL REFERENCES github_installations(installation_id) ON DELETE CASCADE,
+
+  -- What a push is MATCHED on, and why it is the id rather than the name: a
+  -- rename changes `full_name` and keeps `id`, and surviving a rename is the
+  -- entire reason to store this. The name lives beside it for display and for
+  -- API paths, and is refreshed from every webhook payload — so the two can
+  -- disagree for exactly as long as it takes the next push to arrive.
+  repo_id         bigint NOT NULL,
+  repo_full_name  text NOT NULL,
+
+  -- The production branch. Only pushes to this one ship.
+  branch          text NOT NULL,
+
+  -- On from the moment a repository is connected, which is what a person who
+  -- just connected a repository expects to happen. The switch exists so that
+  -- expectation is reversible, not so it has to be opted into.
+  auto_deploy     boolean NOT NULL DEFAULT true,
+
+  connected_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- The query a webhook makes, and the only one on a path somebody is waiting on:
+-- "which app, if any, does this push belong to".
+CREATE INDEX IF NOT EXISTS app_repos_repo_branch ON app_repos (repo_id, branch);
+
+-- Who connected the account, in GitHub's own terms.
+--
+-- 032 records `connected_by`, which is OUR user id — the right answer to "whose
+-- workspace is this" and no answer at all to "was this push by that person".
+-- A push carries a GitHub login and nothing else, so comparing it needs a
+-- GitHub login to compare against.
+--
+-- NULL for an organisation installation, deliberately and permanently: GitHub
+-- does not say which member installed it, and CONTEXT.md is explicit that a
+-- wrong name in "who did it" is worse than no name. So an org push answers
+-- `someone`, which is the honest reading rather than a gap.
+ALTER TABLE github_installations ADD COLUMN IF NOT EXISTS connected_login text;
+
+-- Which commit a build was of.
+--
+-- `builds` (021) is already the one durable row per shipping attempt, and a
+-- build caused by a push is meaningless without the commit that caused it: the
+-- timeline cannot show it, and nothing can find the SHA to report an outcome
+-- against once the deploy run row is deleted.
+--
+-- All four stay NULL for a CLI deploy and for an upload, which is the honest
+-- answer — those builds have no commit.
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS commit_sha     text;
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS commit_branch  text;
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS commit_message text;
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS commit_author  text;

--- a/apps/web/lib/app-repos.ts
+++ b/apps/web/lib/app-repos.ts
@@ -1,0 +1,169 @@
+import { getPool } from "./db";
+
+/**
+ * Every read and write of `app_repos`, and nothing else touches that table.
+ *
+ * The table is small and one query in it is load-bearing: `appForPush` is what
+ * turns an event GitHub sends to everybody into a build of one particular app.
+ * It runs on a path a person is watching, it runs with no session behind it,
+ * and it is the only thing that decides whether a push means anything at all.
+ *
+ * Deliberately knows nothing about GitHub. Whether a push is well-formed is
+ * lib/github-webhook.ts's question; whether anybody asked for it is this one's.
+ */
+
+export type Query = (sql: string, params: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+
+const pool: Query = (sql, params) => getPool("supersonic_platform").query(sql, params);
+
+/**
+ * The binding to write once an app row exists.
+ *
+ * Carried through a deploy rather than written by the route, because
+ * `app_repos.slug` references `apps.slug` — so the link cannot exist until
+ * `createAppRecord` has run, which happens inside the pipeline. The ordering is
+ * forced by the schema, not chosen.
+ */
+export interface RepoLink {
+  installationId: number;
+  repoId: number;
+  repoFullName: string;
+  branch: string;
+}
+
+/** One app's connected repository, as everything but the dispatcher needs it. */
+export interface AppRepo {
+  slug: string;
+  installationId: number;
+  repoId: number;
+  repoFullName: string;
+  branch: string;
+  autoDeploy: boolean;
+  connectedAt: Date | null;
+}
+
+/**
+ * What a push needs to become a build: the link, plus the two fields on `apps`
+ * that a dispatch cannot be assembled without.
+ *
+ * Joined rather than fetched separately because the alternative is two round
+ * trips on the latency path and a window in which the app is deleted between
+ * them — which would dispatch a build for a slug that no longer exists.
+ */
+export interface PushTarget extends AppRepo {
+  ownerId: string;
+  workspaceId: string;
+  repoUrl: string | null;
+  /** The login that connected the account, or null for an organisation. */
+  connectedLogin: string | null;
+}
+
+function toRepo(r: Record<string, unknown>): AppRepo {
+  return {
+    slug: String(r.slug),
+    // bigint arrives as a string through node-postgres. Coerced here, once, so
+    // no caller has to know that and none can forget — the same rule
+    // lib/github-connections.ts states for the same reason.
+    installationId: Number(r.installation_id),
+    repoId: Number(r.repo_id),
+    repoFullName: String(r.repo_full_name),
+    branch: String(r.branch),
+    autoDeploy: r.auto_deploy !== false,
+    connectedAt: r.connected_at ? new Date(String(r.connected_at)) : null,
+  };
+}
+
+/**
+ * Connect an app to a branch, or re-point one that is already connected.
+ *
+ * Upsert, because re-connecting is how a person moves an app to a different
+ * repository or a different branch, and it arrives as the same slug. An INSERT
+ * would fail on the primary key and the ordinary act would read as a bug.
+ *
+ * `auto_deploy` is NOT in the DO UPDATE set. Somebody who turned it off and
+ * later re-points the branch has not asked for it back, and silently
+ * re-enabling it would start shipping on a push they thought they had stopped.
+ */
+export async function linkRepo(
+  o: { slug: string; installationId: number; repoId: number; repoFullName: string; branch: string },
+  q: Query = pool,
+): Promise<void> {
+  await q(
+    `INSERT INTO app_repos (slug, installation_id, repo_id, repo_full_name, branch)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (slug) DO UPDATE SET
+       installation_id = EXCLUDED.installation_id,
+       repo_id         = EXCLUDED.repo_id,
+       repo_full_name  = EXCLUDED.repo_full_name,
+       branch          = EXCLUDED.branch,
+       connected_at    = now()`,
+    [o.slug, o.installationId, o.repoId, o.repoFullName, o.branch],
+  );
+}
+
+export async function repoForSlug(slug: string, q: Query = pool): Promise<AppRepo | null> {
+  if (!slug) return null;
+  const { rows } = await q(`SELECT * FROM app_repos WHERE slug = $1`, [slug]);
+  return rows[0] ? toRepo(rows[0]) : null;
+}
+
+/**
+ * The app a push belongs to, or null.
+ *
+ * Matched on `(repo_id, branch)` — the id rather than the name, so a repository
+ * renamed in GitHub keeps shipping. Returns the row even when `auto_deploy` is
+ * off: "nobody connected this" and "somebody connected it and turned it off"
+ * are different answers, the webhook says which in its response body, and a
+ * query that collapsed them would make the switch impossible to debug.
+ */
+export async function appForPush(repoId: number, branch: string, q: Query = pool): Promise<PushTarget | null> {
+  if (!Number.isInteger(repoId) || repoId <= 0 || !branch) return null;
+  const { rows } = await q(
+    `SELECT r.*, a.owner_id, a.workspace_id, a.repo_url, i.connected_login
+       FROM app_repos r
+       JOIN apps a ON a.slug = r.slug
+       JOIN github_installations i ON i.installation_id = r.installation_id
+      WHERE r.repo_id = $1 AND r.branch = $2`,
+    [repoId, branch],
+  );
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    ...toRepo(row),
+    ownerId: String(row.owner_id),
+    workspaceId: String(row.workspace_id),
+    repoUrl: row.repo_url == null ? null : String(row.repo_url),
+    connectedLogin: row.connected_login == null ? null : String(row.connected_login),
+  };
+}
+
+/**
+ * Keep the stored name in step with GitHub's.
+ *
+ * Called from the webhook on every push, because a rename produces no event we
+ * subscribe to — the first time we hear about it is the next push, in a payload
+ * that carries the new name beside the unchanged id. Writing it here is what
+ * keeps the display name and the API paths from going stale silently.
+ *
+ * A no-op when the name has not moved, so the common push costs one cheap
+ * UPDATE that matches nothing.
+ */
+export async function refreshRepoName(repoId: number, fullName: string, q: Query = pool): Promise<void> {
+  if (!Number.isInteger(repoId) || repoId <= 0 || !fullName) return;
+  await q(
+    `UPDATE app_repos SET repo_full_name = $2 WHERE repo_id = $1 AND repo_full_name <> $2`,
+    [repoId, fullName],
+  );
+}
+
+export async function setBranch(slug: string, branch: string, q: Query = pool): Promise<void> {
+  await q(`UPDATE app_repos SET branch = $2 WHERE slug = $1`, [slug, branch]);
+}
+
+export async function setAutoDeploy(slug: string, on: boolean, q: Query = pool): Promise<void> {
+  await q(`UPDATE app_repos SET auto_deploy = $2 WHERE slug = $1`, [slug, on]);
+}
+
+export async function unlinkRepo(slug: string, q: Query = pool): Promise<void> {
+  await q(`DELETE FROM app_repos WHERE slug = $1`, [slug]);
+}

--- a/apps/web/lib/builds.ts
+++ b/apps/web/lib/builds.ts
@@ -26,12 +26,39 @@ export interface BuildRow {
   outcome: "ok" | "failed" | null;
 }
 
+/**
+ * The commit a build was of, when one caused it.
+ *
+ * Absent for a CLI deploy and for an upload, and that absence is the honest
+ * answer rather than a gap — those builds have no commit. Every field is
+ * written together or not at all, because a SHA with no branch beside it is a
+ * row nothing can render and nothing can report an outcome against.
+ */
+export interface Commit {
+  sha: string;
+  branch: string;
+  message: string;
+  author: string;
+}
+
 /** Split out from the write so the normalisation is testable without a database. */
-export function buildStartSql(runId: string, slug: string, who: string | null | undefined) {
+export function buildStartSql(runId: string, slug: string, who: string | null | undefined, commit?: Commit | null) {
+  // Four columns that are always null together. Written as one branch rather
+  // than four COALESCEs so the "no commit" case produces exactly the statement
+  // it produced before commits existed — a push cannot change what an upload
+  // records.
+  if (!commit) {
+    return {
+      text: `INSERT INTO builds(run_id, slug, who) VALUES($1,$2,$3)
+               ON CONFLICT (run_id) DO NOTHING`,
+      values: [runId, slug, normaliseWho(who)],
+    };
+  }
   return {
-    text: `INSERT INTO builds(run_id, slug, who) VALUES($1,$2,$3)
+    text: `INSERT INTO builds(run_id, slug, who, commit_sha, commit_branch, commit_message, commit_author)
+             VALUES($1,$2,$3,$4,$5,$6,$7)
              ON CONFLICT (run_id) DO NOTHING`,
-    values: [runId, slug, normaliseWho(who)],
+    values: [runId, slug, normaliseWho(who), commit.sha, commit.branch, commit.message, commit.author],
   };
 }
 
@@ -43,8 +70,8 @@ export function buildFinishSql(runId: string, outcome: "ok" | "failed") {
 }
 
 /** Best-effort, both of them: losing the record of a build must not fail the build. */
-export async function startBuild(runId: string, slug: string, who: string | null | undefined): Promise<void> {
-  const q = buildStartSql(runId, slug, who);
+export async function startBuild(runId: string, slug: string, who: string | null | undefined, commit?: Commit | null): Promise<void> {
+  const q = buildStartSql(runId, slug, who, commit);
   try { await getPool(DB).query(q.text, q.values); } catch { /* ignore */ }
 }
 

--- a/apps/web/lib/deploy-one.ts
+++ b/apps/web/lib/deploy-one.ts
@@ -2,6 +2,7 @@ import { runDeploy, type DeployInput } from "@/lib/deploy-pipeline";
 import { eventSink } from "@/lib/deploy-events";
 import { claimRun, finishRun } from "@/lib/deploy-runs";
 import { finishBuild, watchOutcome } from "@/lib/builds";
+import { reportOutcome } from "@/lib/github-deploy";
 import { setDeploy } from "@/lib/deploys";
 
 /**
@@ -56,6 +57,10 @@ export async function deployOne(runId: string, hooks: DeployOneHooks = {}): Prom
     // `?? null` rather than assumed present: rows written before this column
     // existed are still in the table and still get claimed.
     ghInstallationId: request.ghInstallationId ?? null,
+    // Same `?? null` and the same reason: every run row written before pushes
+    // existed is still claimable and carries no commit.
+    commitSha: request.commitSha ?? null,
+    connect: request.connect ?? null,
     isUpload: request.isUpload,
     isPrebuilt: request.isPrebuilt,
     prebuiltHash: request.prebuiltHash,
@@ -96,6 +101,16 @@ export async function deployOne(runId: string, hooks: DeployOneHooks = {}): Prom
     // outcome: null` forever — the app's timeline claims every build it ever ran
     // is still in flight, and a failure is indistinguishable from a success.
     await finishBuild(runId, watch.outcome);
+    // And on the commit, when a push is what caused this. Everything it needs
+    // is in the request row, so this costs no query — and it cannot throw, so
+    // it cannot replace the outcome above with an error about GitHub.
+    await reportOutcome({
+      installationId: request.ghInstallationId ?? null,
+      repoUrl: request.repoUrl,
+      commitSha: request.commitSha ?? null,
+      slug: request.slug,
+      outcome: watch.outcome,
+    }).catch(() => { /* best-effort, by contract */ });
   }
   return "deployed";
 }

--- a/apps/web/lib/deploy-pipeline.ts
+++ b/apps/web/lib/deploy-pipeline.ts
@@ -46,6 +46,7 @@ import { releaseId, releasePrefix, pointerPath, ASSETS_BUCKET } from "@/lib/stat
 import { listObjectNames, readObjectText, writeObject, describeServiceRest, resolveImageDigest, imageExposedPort, accessToken } from "@/lib/gcp-rest";
 import { take as takeClone } from "@/lib/clone-cache";
 import { cloneTokenFor } from "@/lib/github-clone";
+import { linkRepo, type RepoLink } from "@/lib/app-repos";
 import { staticBuildConfig } from "@/lib/static-build";
 import { verifyRelease } from "@/lib/verify-release";
 import { StageRecorder, ACTIVATION_STAGE } from "@/lib/stages";
@@ -1078,6 +1079,15 @@ export interface DeployInput {
    * the deploy job, and a check in one of them is a check the other two skip.
    */
   ghInstallationId: number | null;
+  /**
+   * The commit to build, or null for "whatever the branch points at".
+   *
+   * Null is every deploy that existed before pushes did — an upload, a CLI run,
+   * a public URL — and for those the clone is byte-for-byte what it always was.
+   */
+  commitSha: string | null;
+  /** The repository binding to write right after the app row exists, or null. */
+  connect: RepoLink | null;
   isUpload: boolean;
   isPrebuilt: boolean;
   prebuiltHash: string;
@@ -1133,6 +1143,16 @@ export async function runDeploy(input: DeployInput, emit: (e: unknown) => void):
         repoUrl: redeployableRepo({ url, isUpload }),
         ghInstallationId: input.ghInstallationId,
       });
+      // Immediately after, and never before: `app_repos.slug` references
+      // `apps.slug`, so the row above is what makes this one legal. Best-effort
+      // on purpose — a deploy that built and went live must not be reported as
+      // failed because the thing that makes the NEXT one automatic could not be
+      // written. The person can connect it again from the app's own panel.
+      if (input.connect) {
+        await linkRepo({ slug, ...input.connect }).catch((e) => {
+          log(`Could not connect ${input.connect?.repoFullName} for future pushes: ${e instanceof Error ? e.message : String(e)}`);
+        });
+      }
     }
     // /api/detect already cloned this repo moments ago. Reuse that clone when
     // it is still around. A miss — a different control-plane instance, an
@@ -1186,7 +1206,7 @@ export async function runDeploy(input: DeployInput, emit: (e: unknown) => void):
       dir,
       isUpload && archive ? { kind: "upload", archive }
         : reused ? { kind: "cached-clone" }
-        : { kind: "clone", url, token: gitToken },
+        : { kind: "clone", url, token: gitToken, sha: input.commitSha ?? undefined },
       { run: (cmd, args) => run(cmd, args, () => {}), log, stages },
     );
 

--- a/apps/web/lib/deploy-runs.ts
+++ b/apps/web/lib/deploy-runs.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { getPool } from "./db";
 import { HTTP_TIMEOUT_MS, accessToken, identityToken, imageTag, runJobUrl, runServiceUrl } from "./gcp-rest";
 import { ASSETS_BUCKET } from "./static-release";
+import type { RepoLink } from "./app-repos";
 
 const DB = "supersonic_platform";
 const PROJECT = "supersonic-deploy-prod";
@@ -62,6 +63,30 @@ export interface DeployRunRequest {
    * that might already be spent.
    */
   ghInstallationId: number | null;
+  /**
+   * The commit this build is OF, when a push caused it. Null everywhere else.
+   *
+   * Pinned here rather than resolved when the builder starts, and the reason is
+   * measured: `app/api/deploy/route.ts` records 79 to 227 seconds between a
+   * deploy being recorded and the builder's first line. On a repository
+   * somebody is pushing to, HEAD moves inside that window — so cloning HEAD
+   * would build code the platform was never told about and then report the
+   * outcome on the wrong commit.
+   *
+   * A SHA travels here for the same reason an installation id does and a token
+   * does not: it is a fact, not a credential, and it is still true when a job
+   * claims this row minutes later.
+   */
+  commitSha: string | null;
+  /**
+   * The repository binding to write once this app's row exists, or null.
+   *
+   * Set only by the GitHub door, and only on the deploy that CONNECTS — every
+   * later build of the app finds the link already in `app_repos`. It travels
+   * here because the link cannot be written before `createAppRecord`, and that
+   * runs inside the pipeline rather than in the route.
+   */
+  connect: RepoLink | null;
   isUpload: boolean;
   isPrebuilt: boolean;
   prebuiltHash: string;

--- a/apps/web/lib/github-connections.ts
+++ b/apps/web/lib/github-connections.ts
@@ -25,6 +25,20 @@ export interface Connection {
   accountLogin: string;
   accountType: string;
   connectedBy: string | null;
+  /**
+   * The GitHub login of whoever installed the App, or null.
+   *
+   * `connectedBy` is OUR user id, which answers "whose workspace is this" and
+   * cannot answer "was this push by that person" — a push carries a GitHub
+   * login and nothing else. Null for an organisation, permanently: GitHub does
+   * not say which member installed it.
+   *
+   * Optional on the type as well as nullable in the column, because
+   * `connectionsForWorkspace` is read on a database that may not have run 033
+   * yet, and a type promising `string | null` would be lying in exactly the
+   * window where being wrong costs most.
+   */
+  connectedLogin?: string | null;
 }
 
 /**
@@ -51,15 +65,16 @@ function plausible(id: number): boolean {
 export async function recordInstallation(c: Connection, q: Query = pool): Promise<void> {
   await q(
     `INSERT INTO github_installations
-       (installation_id, workspace_id, account_login, account_type, connected_by)
-     VALUES ($1, $2, $3, $4, $5)
+       (installation_id, workspace_id, account_login, account_type, connected_by, connected_login)
+     VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT (installation_id) DO UPDATE SET
-       workspace_id  = EXCLUDED.workspace_id,
-       account_login = EXCLUDED.account_login,
-       account_type  = EXCLUDED.account_type,
-       connected_by  = COALESCE(EXCLUDED.connected_by, github_installations.connected_by),
-       updated_at    = now()`,
-    [c.installationId, c.workspaceId, c.accountLogin, c.accountType, c.connectedBy],
+       workspace_id    = EXCLUDED.workspace_id,
+       account_login   = EXCLUDED.account_login,
+       account_type    = EXCLUDED.account_type,
+       connected_by    = COALESCE(EXCLUDED.connected_by, github_installations.connected_by),
+       connected_login = COALESCE(EXCLUDED.connected_login, github_installations.connected_login),
+       updated_at      = now()`,
+    [c.installationId, c.workspaceId, c.accountLogin, c.accountType, c.connectedBy, c.connectedLogin ?? null],
   );
 }
 
@@ -69,7 +84,7 @@ export async function connectionsForWorkspace(workspaceId: string, q: Query = po
   // depend on how Postgres compares uuid to ''.
   if (!workspaceId) return [];
   const { rows } = await q(
-    `SELECT installation_id, workspace_id, account_login, account_type, connected_by
+    `SELECT installation_id, workspace_id, account_login, account_type, connected_by, connected_login
        FROM github_installations
       WHERE workspace_id = $1
       ORDER BY account_login`,
@@ -83,6 +98,7 @@ export async function connectionsForWorkspace(workspaceId: string, q: Query = po
     accountLogin: String(r.account_login),
     accountType: String(r.account_type),
     connectedBy: r.connected_by == null ? null : String(r.connected_by),
+    connectedLogin: r.connected_login == null ? null : String(r.connected_login),
   }));
 }
 
@@ -98,4 +114,21 @@ export async function workspaceOwnsInstallation(
     [workspaceId, installationId],
   );
   return rows.length > 0;
+}
+
+/**
+ * Forget a connection, because GitHub says it is gone.
+ *
+ * Called from the webhook on `installation.deleted`, which is the only event
+ * that can tell us — an uninstall happens in GitHub's UI and nothing else here
+ * would ever find out. Every `app_repos` row referencing it cascades, so every
+ * app it connected stops shipping on push.
+ *
+ * The apps themselves are untouched and keep running. Uninstalling the App
+ * removes an automation, not a deployment, and a person who uninstalls it to
+ * "disconnect GitHub" must not lose their live site by doing so.
+ */
+export async function forgetInstallation(installationId: number, q: Query = pool): Promise<void> {
+  if (!plausible(installationId)) return;
+  await q(`DELETE FROM github_installations WHERE installation_id = $1`, [installationId]);
 }

--- a/apps/web/lib/github-deploy.ts
+++ b/apps/web/lib/github-deploy.ts
@@ -1,0 +1,256 @@
+import { randomUUID } from "node:crypto";
+import { cloudRunName } from "@/lib/slug";
+import { fullNameFromUrl } from "@/lib/github-repos";
+import { entitlement } from "@/lib/entitlements";
+import { countIfUnder } from "@/lib/usage";
+import { createRun, startDeployRun, finishRun } from "@/lib/deploy-runs";
+import { startBuild, finishBuild, type Commit } from "@/lib/builds";
+import { appForPush, refreshRepoName, type PushTarget } from "@/lib/app-repos";
+import { postCommitStatus, type StatusPost } from "@/lib/github-status";
+import type { Push } from "@/lib/github-webhook";
+
+/**
+ * What a push means, and how it becomes a build.
+ *
+ * The last step here is the same `createRun` → `startDeployRun` pair that
+ * `app/api/deploy/route.ts` uses in its `DEPLOY_JOB` branch, and that is the
+ * point of the module. A second dispatch path would be a second place for the
+ * quota, the supersede, the build record and the outcome to be got wrong, and
+ * the two would drift the first time either was touched.
+ *
+ * What is genuinely different is everything BEFORE the dispatch: there is no
+ * session, no request body to trust and nobody to return an error to. So every
+ * refusal is a value, named, that the route puts in a 200 body — see
+ * lib/github-webhook.ts on why a delivery that did nothing must still say why.
+ */
+
+const REGION = "us-central1";
+const DEPLOY_JOB = process.env.DEPLOY_JOB === "1";
+const DEPLOY_JOB_NAME = process.env.DEPLOY_JOB_NAME || "supersonic-deploy-job";
+
+export type ShipResult =
+  | { shipped: true; slug: string; runId: string }
+  | { shipped: false; reason: string; slug?: string };
+
+/**
+ * Who caused this build, in the only terms that can be known.
+ *
+ * CONTEXT.md is explicit: *"When nobody said, the answer is `someone` — never a
+ * guess, because a wrong name here is worse than no name."* What is known is
+ * the login that connected the account and the login that pushed. When they
+ * match, `you` is a fact. When they do not — a colleague, a bot, a merge queue
+ * — the answer is `someone`, and `builds.commit_author` still carries the name
+ * so a page can show WHO without the platform claiming it was the owner.
+ *
+ * An organisation installation names nobody, so `connectedLogin` is null for
+ * one and every org push answers `someone`. That is the honest reading, not a
+ * gap to be filled later.
+ */
+export function whoPushed(senderLogin: string, connectedLogin: string | null): "you" | "someone" {
+  if (!connectedLogin || !senderLogin) return "someone";
+  return senderLogin.toLowerCase() === connectedLogin.toLowerCase() ? "you" : "someone";
+}
+
+/**
+ * The URL the clone is made from.
+ *
+ * Built from the name in THIS push rather than read from `apps.repo_url`,
+ * because a rename is invisible until a push arrives carrying the new name
+ * beside the unchanged id — so the payload is the freshest thing we will ever
+ * have, and the stored column is by definition one rename behind.
+ */
+export function cloneUrlForPush(fullName: string): string {
+  return `https://github.com/${fullName}.git`;
+}
+
+/**
+ * Everything `shipPush` reaches outside itself.
+ *
+ * Six seams rather than a mockable module, following `ReposDeps`, `MintDeps`
+ * and `ImportDeps` in the modules beside this one. The function they serve is
+ * the one that decides whether a `git push` becomes a build, it runs with no
+ * session and nobody watching, and every branch in it should be assertable
+ * without a database, a GitHub and a Cloud Run job.
+ */
+export interface ShipDeps {
+  target: (repoId: number, branch: string) => Promise<PushTarget | null>;
+  refreshName: (repoId: number, fullName: string) => Promise<void>;
+  /** The plan, or a refusal. `locked` is an account that cannot build at all. */
+  plan: (ownerId: string) => Promise<{ locked: boolean; monthlyBuilds: number }>;
+  /** Charge one build against the meter. False means the ceiling was reached. */
+  charge: (ownerId: string, limit: number) => Promise<boolean>;
+  record: (runId: string, slug: string, who: string, commit: Commit) => Promise<void>;
+  dispatch: (runId: string, target: PushTarget, push: Push, limits: unknown) => Promise<void>;
+  status: (o: StatusPost) => Promise<boolean>;
+  /** Whether deploys execute in a job at all. False refuses rather than hangs. */
+  jobEnabled: boolean;
+}
+
+const liveShip: ShipDeps = {
+  target: appForPush,
+  refreshName: (id, name) => refreshRepoName(id, name),
+  plan: async (ownerId) => {
+    const ent = await entitlement(ownerId);
+    return { locked: ent.locked, monthlyBuilds: ent.limits.monthlyBuilds };
+  },
+  charge: (ownerId, limit) => countIfUnder(ownerId, "builds", limit),
+  record: (runId, slug, who, commit) => startBuild(runId, slug, who, commit),
+  dispatch: liveDispatch,
+  status: (o) => postCommitStatus(o),
+  jobEnabled: DEPLOY_JOB,
+};
+
+/**
+ * Ship a push, or say why not.
+ *
+ * The order below is not arbitrary. The link is resolved first, because most
+ * deliveries are for repositories nobody connected and those must cost one
+ * indexed query and nothing else. The meter is charged before the dispatch,
+ * because we pay for a build that fails exactly as much as for one that works
+ * — a meter that only counted successes is one a broken repository can evade.
+ * The pending status goes out last, after the build is real, so a tick never
+ * appears for a build that was refused.
+ */
+export async function shipPush(push: Push, over: Partial<ShipDeps> = {}): Promise<ShipResult> {
+  const d: ShipDeps = { ...liveShip, ...over };
+
+  const target = await d.target(push.repoId, push.branch);
+  if (!target) return { shipped: false, reason: "no-app-follows-this-branch" };
+  if (!target.autoDeploy) return { shipped: false, reason: "auto-deploy-off", slug: target.slug };
+
+  // The stored name, in step with GitHub's. A rename produces no event we
+  // subscribe to, so the first we hear of it is a push carrying the new name
+  // beside the unchanged id. Swallowed: a stale display name must never stop a
+  // build.
+  await d.refreshName(push.repoId, push.repoFullName).catch(() => {});
+
+  // Refused here rather than let through and failed later: a build that cannot
+  // be dispatched must not leave a `pending` status on a commit that nothing
+  // will ever come back to resolve.
+  if (!d.jobEnabled) return { shipped: false, reason: "deploy-job-disabled", slug: target.slug };
+
+  const plan = await d.plan(target.ownerId);
+  if (plan.locked) return { shipped: false, reason: "no-account", slug: target.slug };
+  if (!(await d.charge(target.ownerId, plan.monthlyBuilds))) {
+    return { shipped: false, reason: "build-limit-reached", slug: target.slug };
+  }
+
+  const runId = randomUUID();
+
+  // The durable record of this attempt, written before anything can fail, so a
+  // build that dies in its first second still appears on the app's timeline —
+  // the same reason and the same placement as the route's.
+  await d.record(runId, target.slug, whoPushed(push.senderLogin, target.connectedLogin), {
+    sha: push.sha,
+    branch: push.branch,
+    message: push.message,
+    author: push.author,
+  });
+
+  try {
+    await d.dispatch(runId, target, push, { monthlyBuilds: plan.monthlyBuilds });
+  } catch (e) {
+    // The run record holds the app's secrets and exists only so a job can pick
+    // it up. If no job ever will, it is deleted now rather than left for the
+    // six-hour sweep.
+    await finishRun(runId).catch(() => {});
+    await finishBuild(runId, "failed").catch(() => {});
+    await d.status({
+      installationId: target.installationId,
+      fullName: push.repoFullName,
+      sha: push.sha,
+      // `error`, not `failure`: the build never ran, so there is no verdict on
+      // the code. See `reportOutcome`, which owns the other word.
+      state: "error",
+      slug: target.slug,
+      description: `Could not start the build: ${e instanceof Error ? e.message : String(e)}`,
+    });
+    return { shipped: false, reason: "dispatch-failed", slug: target.slug };
+  }
+
+  await d.status({
+    installationId: target.installationId,
+    fullName: push.repoFullName,
+    sha: push.sha,
+    state: "pending",
+    slug: target.slug,
+    // The Room: the app's own address, which is where a person watches the
+    // build happen and which becomes the app itself the moment it opens.
+    targetUrl: `https://${target.slug}.supersonic.cv`,
+    description: "Building…",
+  });
+
+  return { shipped: true, slug: target.slug, runId };
+}
+
+/** The real dispatch, kept behind a seam so `shipPush` is testable without GCP. */
+async function liveDispatch(runId: string, target: PushTarget, push: Push, limits: unknown): Promise<void> {
+  const url = cloneUrlForPush(push.repoFullName);
+  await createRun(
+    {
+      ownerId: target.ownerId,
+      ownerWorkspace: target.workspaceId,
+      slug: target.slug,
+      friendlyName: cloudRunName(url),
+      repoUrl: url,
+      ghInstallationId: target.installationId,
+      // Pinned, which is the whole reason the column exists. See
+      // `commitSha` in lib/deploy-runs.ts.
+      commitSha: push.sha,
+      // Already connected — that is what made this push a build. The link is
+      // written by the deploy that CONNECTS and read by every one after it.
+      connect: null,
+      isUpload: false,
+      isPrebuilt: false,
+      prebuiltHash: "",
+      secrets: {},
+      cloneToken: null,
+      runCmd: "",
+      limits,
+    },
+    null,
+    null,
+    runId,
+  );
+  await startDeployRun(runId, REGION, DEPLOY_JOB_NAME);
+}
+
+/**
+ * Tell the commit how its build ended.
+ *
+ * Called from the `finally` in lib/deploy-one.ts, beside `finishBuild`, and for
+ * the same reason it is there: that block is the one place every ending passes
+ * through — success, failure, and a pipeline that threw on its way out.
+ *
+ * Everything it needs is already in the run row, so it asks the database
+ * nothing. A build with no installation or no commit is every deploy that was
+ * not caused by a push, and those return without a request.
+ *
+ * Never throws. `postCommitStatus` is best-effort by contract and this adds no
+ * new way to fail — a deploy that worked must not be reported as failed because
+ * GitHub would not take a status.
+ */
+export async function reportOutcome(o: {
+  installationId: number | null;
+  repoUrl: string;
+  commitSha: string | null;
+  slug: string;
+  outcome: "ok" | "failed";
+}): Promise<void> {
+  if (o.installationId == null || !o.commitSha) return;
+  const fullName = fullNameFromUrl(o.repoUrl);
+  if (!fullName) return;
+  const url = `https://${o.slug}.supersonic.cv`;
+  await postCommitStatus({
+    installationId: o.installationId,
+    fullName,
+    sha: o.commitSha,
+    // `failure`, not `error`: the build ran and produced a verdict. `error` is
+    // reserved for the case where it never got to run at all, which is what
+    // `shipPush` reports when the dispatch itself fails.
+    state: o.outcome === "ok" ? "success" : "failure",
+    slug: o.slug,
+    targetUrl: url,
+    description: o.outcome === "ok" ? `Live at ${o.slug}.supersonic.cv` : "The build failed",
+  });
+}

--- a/apps/web/lib/github-repos.ts
+++ b/apps/web/lib/github-repos.ts
@@ -14,6 +14,15 @@ const API = "https://api.github.com";
 const PER_PAGE = 100;
 
 export interface Repo {
+  /**
+   * GitHub's id for the repository, and what a push is matched on.
+   *
+   * The name is what a person picks from and the id is what survives them
+   * renaming it afterwards, so the picker carries both: `app_repos.repo_id` is
+   * written from here, and a connection that outlives a rename is the reason
+   * the column exists at all.
+   */
+  id: number;
   fullName: string;
   private: boolean;
   defaultBranch: string;
@@ -62,6 +71,7 @@ export async function listRepos(installationId: number, deps: ReposDeps = live):
     const batch = body.repositories ?? [];
     for (const r of batch) {
       out.push({
+        id: Number(r.id),
         fullName: String(r.full_name),
         private: Boolean(r.private),
         defaultBranch: String(r.default_branch ?? "main"),
@@ -93,4 +103,57 @@ export function authenticatedCloneUrl(repoUrl: string, token: string): string {
 /** Mint for this installation and hand back a URL `git clone` can use. */
 export async function cloneUrlFor(installationId: number, repoUrl: string, deps: ReposDeps = live): Promise<string> {
   return authenticatedCloneUrl(repoUrl, await deps.token(installationId));
+}
+
+/**
+ * `owner/repo` out of whatever form the repository URL arrived in.
+ *
+ * Empty string when it is not a GitHub URL at all, which is a real case rather
+ * than an error: the URL door still accepts GitLab, a self-hosted git, and a
+ * `file://` path, and none of those can be connected to a push.
+ *
+ * The `.git` suffix and a trailing slash are both stripped because both are
+ * things people paste, and `owner/repo.git` is not a name any GitHub API path
+ * accepts.
+ */
+export function fullNameFromUrl(url: string): string {
+  const m = /^(?:https?:\/\/)?(?:[^@/]*@)?github\.com[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/i.exec(url.trim());
+  return m ? `${m[1]}/${m[2]}` : "";
+}
+
+/**
+ * One repository, as this installation sees it.
+ *
+ * Exists so a connection is never written from a name and an id the CLIENT
+ * supplied. The picker knows both, and posting them would be faster — but an
+ * installation id in a request body is already only a claim (see
+ * lib/github-connections.ts), and a repository id beside it would be a second
+ * one, checked by nothing, written into the column that decides which pushes
+ * ship. Asking GitHub costs one request at connect time and makes the id a fact.
+ *
+ * Null when this installation cannot see the repository, which covers both "it
+ * does not exist" and "you were not given it" — GitHub answers 404 to each, on
+ * purpose, and the person's next step is the same for both: widen the
+ * installation's selection.
+ */
+export async function repoFor(installationId: number, fullName: string, deps: ReposDeps = live): Promise<Repo | null> {
+  if (!/^[\w.-]+\/[\w.-]+$/.test(fullName)) return null;
+  const token = await deps.token(installationId);
+  const res = await deps.fetch(`${API}/repos/${fullName}`, {
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "supersonic",
+    },
+  });
+  if (!res.ok) return null;
+  const r = (await res.json()) as Record<string, unknown>;
+  return {
+    id: Number(r.id),
+    fullName: String(r.full_name),
+    private: Boolean(r.private),
+    defaultBranch: String(r.default_branch ?? "main"),
+    pushedAt: r.pushed_at == null ? null : String(r.pushed_at),
+  };
 }

--- a/apps/web/lib/github-status.ts
+++ b/apps/web/lib/github-status.ts
@@ -1,0 +1,137 @@
+import { installationToken } from "./github-app";
+
+/**
+ * Say on the commit what happened to it.
+ *
+ * A commit status rather than a Check Run. It is one API call, it renders in
+ * the same place — on the commit, and in any pull request the commit is in —
+ * and a Check Run would buy us a log-rendering surface we would then have to
+ * fill, when the log already has a home at the app's own address.
+ *
+ * ## Best-effort, by contract
+ *
+ * Every function here resolves. None of them throws, for any reason, including
+ * a GitHub that is down or a token that cannot be minted. Two callers depend on
+ * that: the dispatcher, where a failed status write must not stop a build that
+ * a person is waiting for, and the `finally` in lib/deploy-one.ts, where a
+ * throw would replace the deploy's real outcome with an error about GitHub.
+ *
+ * A deploy that worked being reported as failed because a status could not be
+ * written is strictly worse than no status at all.
+ */
+
+const API = "https://api.github.com";
+
+export type StatusState = "pending" | "success" | "failure" | "error";
+
+export interface StatusDeps {
+  fetch: typeof globalThis.fetch;
+  token: (installationId: number) => Promise<string>;
+}
+
+const live: StatusDeps = {
+  fetch: (...a) => globalThis.fetch(...a),
+  token: (id) => installationToken(id),
+};
+
+/**
+ * The name GitHub groups statuses under.
+ *
+ * Per-app rather than a constant, so every build of one app REPLACES that app's
+ * previous status rather than stacking a new one beside it — and so a monorepo
+ * with two connected apps can report two independent outcomes on the same
+ * commit without either overwriting the other.
+ */
+export function contextFor(slug: string): string {
+  return `supersonic/${slug}`;
+}
+
+export interface StatusPost {
+  installationId: number;
+  fullName: string;
+  sha: string;
+  state: StatusState;
+  slug: string;
+  targetUrl?: string;
+  description?: string;
+}
+
+/**
+ * Returns whether GitHub accepted it, for a caller that wants to log the
+ * difference. Nobody is required to look.
+ */
+export async function postCommitStatus(o: StatusPost, deps: StatusDeps = live): Promise<boolean> {
+  if (!o.fullName || !/^[0-9a-f]{40}$/i.test(o.sha)) return false;
+  try {
+    const token = await deps.token(o.installationId);
+    const res = await deps.fetch(`${API}/repos/${o.fullName}/statuses/${o.sha}`, {
+      method: "POST",
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "supersonic",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        state: o.state,
+        target_url: o.targetUrl,
+        // GitHub truncates past 140 characters. Doing it here keeps the
+        // sentence ours to end rather than GitHub's to cut mid-word.
+        description: (o.description ?? "").slice(0, 140),
+        context: contextFor(o.slug),
+      }),
+    });
+    if (!res.ok) {
+      // 403 here is the one worth recognising on sight: it means the App holds
+      // no `statuses: write`, which is a permission a human grants once and
+      // nothing in this process can repair.
+      console.error(`github: status ${o.state} on ${o.fullName}@${o.sha.slice(0, 7)} refused (${res.status})`);
+    }
+    return res.ok;
+  } catch (e) {
+    console.error("github: could not post a commit status —", e instanceof Error ? e.message : String(e));
+    return false;
+  }
+}
+
+/**
+ * Where a branch points right now.
+ *
+ * Asked at dispatch so the FIRST build of a newly connected repository is
+ * pinned to a commit, exactly as every push-triggered one is. Without it the
+ * first build would be of "whatever HEAD is when the builder starts" and would
+ * have no SHA to report an outcome against — so the first build of an app, the
+ * one its owner is watching hardest, would be the only build that never gets a
+ * tick in GitHub.
+ *
+ * Returns null rather than throwing: the caller falls back to an unpinned
+ * clone, which is exactly what every deploy did before this existed.
+ */
+export async function branchHead(
+  installationId: number,
+  fullName: string,
+  branch: string,
+  deps: StatusDeps = live,
+): Promise<string | null> {
+  if (!fullName || !branch) return null;
+  try {
+    const token = await deps.token(installationId);
+    const res = await deps.fetch(`${API}/repos/${fullName}/commits/${encodeURIComponent(branch)}`, {
+      headers: {
+        Authorization: `token ${token}`,
+        // The SHA is all that is wanted, and this media type is how GitHub is
+        // asked for just it. The alternative is parsing one field out of a
+        // commit object that carries the whole diff stat.
+        Accept: "application/vnd.github.sha",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "supersonic",
+      },
+    });
+    if (!res.ok) return null;
+    const sha = (await res.text()).trim();
+    return /^[0-9a-f]{40}$/i.test(sha) ? sha : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/github-webhook.ts
+++ b/apps/web/lib/github-webhook.ts
@@ -1,0 +1,140 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * What GitHub sent, and whether it really was GitHub.
+ *
+ * Two things live here and they are the same job seen from two sides: proving
+ * the request is genuine, and reading the one event we act on. Both are pure
+ * functions of bytes, so the route around them is plumbing — the same split
+ * lib/github-import.ts already uses, for the same reason: the decisions that
+ * have to be right should be testable without a Request.
+ *
+ * ## This is the whole security boundary
+ *
+ * `/api/github/webhook` is exempt from the cookie gate, beside Stripe's. Behind
+ * it sits code that can clone a private repository, run a container and deploy
+ * to a live address under our own service account. There is no session, no
+ * user, and no second check further in — the HMAC is it.
+ */
+
+const ZERO_SHA = "0000000000000000000000000000000000000000";
+
+function secret(): string {
+  return (process.env.GH_WEBHOOK_SECRET ?? "").trim();
+}
+
+/**
+ * Whether the platform can verify a delivery at all.
+ *
+ * Named separately from "is this signature valid" because the two failures are
+ * unrelated: an unconfigured platform should answer 503 and say so, while a bad
+ * signature is a 401 and says nothing. Collapsing them would make a missing
+ * environment variable look like an attack in the logs.
+ */
+export function webhookConfigured(): boolean {
+  return secret().length > 0;
+}
+
+/**
+ * HMAC-SHA256 over the RAW body.
+ *
+ * Raw, which is why every caller must read `req.text()` before parsing:
+ * re-serialising the parsed JSON produces different bytes — a reordered key, a
+ * dropped space — and therefore a signature that can never match, for a body
+ * that is byte-identical in every way a person would check.
+ *
+ * Returns false rather than throwing on every malformed shape: a missing
+ * header, a wrong prefix, a digest of the wrong length. `timingSafeEqual`
+ * refuses buffers of unequal length outright, so the length is compared first
+ * and separately — otherwise a short header would be a thrown exception rather
+ * than a rejection, and the route would answer 500 to something it should
+ * simply refuse.
+ */
+export function verifySignature(raw: string, header: string | null | undefined): boolean {
+  const key = secret();
+  if (!key || !header) return false;
+  const expected = "sha256=" + createHmac("sha256", key).update(raw, "utf8").digest("hex");
+  const a = Buffer.from(header, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** One push, reduced to what a build needs to exist. */
+export interface Push {
+  repoId: number;
+  repoFullName: string;
+  branch: string;
+  sha: string;
+  message: string;
+  author: string;
+  /** The GitHub login that pushed, which is not necessarily whose app this is. */
+  senderLogin: string;
+}
+
+/**
+ * Either the push, or the reason there is nothing to do.
+ *
+ * A reason rather than a bare null, because it is the answer the route puts in
+ * its 200 body — GitHub's *Advanced* tab shows the response for every delivery,
+ * and `{"ignored": "not-a-branch"}` is the difference between debugging this in
+ * a minute and reading our logs for an hour.
+ */
+export type PushRead = { ok: true; push: Push } | { ok: false; reason: string };
+
+const s = (v: unknown): string => (typeof v === "string" ? v : "");
+
+/**
+ * Read a push payload.
+ *
+ * Every refusal here is a normal event that we simply do not ship, not an
+ * error: GitHub sends a push for a tag, for a branch being deleted, and for a
+ * branch created with no commits, and all three are ordinary things to do to a
+ * repository.
+ */
+export function readPush(payload: unknown): PushRead {
+  const p = (payload ?? {}) as Record<string, unknown>;
+  const ref = s(p.ref);
+
+  // Tags and notes and anything else that is not a branch. `refs/heads/` is the
+  // only prefix a production branch can have, so this is a whitelist rather
+  // than a list of things to skip — the difference matters the day GitHub adds
+  // a fourth kind of ref.
+  if (!ref.startsWith("refs/heads/")) return { ok: false, reason: "not-a-branch" };
+  const branch = ref.slice("refs/heads/".length);
+  if (!branch) return { ok: false, reason: "not-a-branch" };
+
+  // A deletion arrives as a push whose `after` is all zeroes. Building it would
+  // mean cloning a commit that no longer exists on a branch that no longer
+  // exists, which fails slowly and reports the failure on nothing.
+  const after = s(p.after).toLowerCase();
+  if (p.deleted === true || !after || after === ZERO_SHA) return { ok: false, reason: "branch-deleted" };
+  if (!/^[0-9a-f]{40}$/.test(after)) return { ok: false, reason: "no-commit" };
+
+  const repo = (p.repository ?? {}) as Record<string, unknown>;
+  const repoId = typeof repo.id === "number" ? repo.id : Number(s(repo.id));
+  if (!Number.isInteger(repoId) || repoId <= 0) return { ok: false, reason: "no-repository" };
+
+  const head = (p.head_commit ?? {}) as Record<string, unknown>;
+  const author = (head.author ?? {}) as Record<string, unknown>;
+  const sender = (p.sender ?? {}) as Record<string, unknown>;
+
+  return {
+    ok: true,
+    push: {
+      repoId,
+      repoFullName: s(repo.full_name),
+      branch,
+      sha: after,
+      // First line only. The rest of a commit message is prose and this value
+      // goes in a column a timeline renders on one line; carrying the body
+      // would mean every reader had to trim it, and one of them would forget.
+      message: s(head.message).split("\n")[0].slice(0, 500),
+      // `head_commit.author.name` rather than the sender: the person who wrote
+      // the commit is what a timeline should show, and on a merge queue or a
+      // rebase-and-merge the two are different people.
+      author: s(author.name) || s(author.username),
+      senderLogin: s(sender.login),
+    },
+  };
+}

--- a/apps/web/lib/source.ts
+++ b/apps/web/lib/source.ts
@@ -41,8 +41,12 @@ export type SourceOrigin =
    * authenticated string is a credential: the moment it arrives as `url`, every
    * line that already logs `origin.url` starts leaking it, and nothing about
    * those lines looks wrong.
+   *
+   * `sha` pins the clone to one commit. Set for a build a push caused, absent
+   * for every other kind — and when it is absent this is byte-for-byte the
+   * clone it has always been.
    */
-  | { kind: "clone"; url: string; token?: string };
+  | { kind: "clone"; url: string; token?: string; sha?: string };
 
 export type Log = (line: string) => void;
 
@@ -52,6 +56,54 @@ export interface FetchDeps {
   run: (cmd: string, args: string[]) => Promise<unknown>;
   log: Log;
   stages: Pick<StageRecorder, "around" | "skipped">;
+}
+
+/**
+ * The git commands that put one commit — or one branch tip — in `dir`.
+ *
+ * Returned as data rather than run here so the shape is testable without a
+ * repository, a network or a temp directory. The pinned form is the reason
+ * this function exists at all.
+ *
+ * **`git clone --branch` refuses a SHA.** It takes a branch or a tag and
+ * nothing else, so pinning cannot be expressed as a flag on the clone we
+ * already make. The four-step form below is the documented way to fetch one
+ * commit: init an empty repository, name the remote, `fetch --depth 1` the SHA
+ * itself, and check out what came back. It is still one commit's worth of
+ * bytes — the same as the shallow clone it replaces — and it is exact, which
+ * `--depth 1` of a branch is not once somebody pushes again mid-build.
+ *
+ * `--detach FETCH_HEAD` rather than a branch name: nothing downstream reads the
+ * branch, and creating one would invite a later reader to believe the checkout
+ * tracks it.
+ */
+export function cloneCommands(target: string, dir: string, sha?: string, clean?: string): Array<[string, string[]]> {
+  const cmds: Array<[string, string[]]> = sha
+    ? [
+        ["git", ["init", "--quiet", dir]],
+        ["git", ["-C", dir, "remote", "add", "origin", target]],
+        ["git", ["-C", dir, "fetch", "--depth", "1", "origin", sha]],
+        ["git", ["-C", dir, "checkout", "--detach", "FETCH_HEAD"]],
+      ]
+    : [["git", ["clone", "--depth", "1", target, dir]]];
+
+  // TAKE THE CREDENTIAL BACK OUT OF `.git/config`.
+  //
+  // Both forms above leave the URL they were given as `origin`, and for a
+  // private repository that URL contains an installation token. `.git` is not
+  // excluded from anything downstream: the build context is the whole directory
+  // (`buildctl --local context=<dir>`), and a Dockerfile that says `COPY . .`
+  // copies the token into a layer of an image pushed to a shared repository.
+  //
+  // The token lives an hour, which bounds the damage and does not remove it —
+  // an image layer is permanent and an hour is long enough to clone every
+  // repository the installation can see.
+  //
+  // Rewriting the remote is preferred over deleting `.git`, which some builders
+  // read for version metadata. A no-op when no token was used, so a public
+  // clone runs exactly the one command it always ran.
+  if (clean && clean !== target) cmds.push(["git", ["-C", dir, "remote", "set-url", "origin", clean]]);
+  return cmds;
 }
 
 /**
@@ -79,9 +131,9 @@ export async function fetchSource(dir: string, origin: SourceOrigin, deps: Fetch
     await stages.around("clone", async () => {
       // The clean url is logged; the authenticated one is built here, handed to
       // git, and never bound to anything a later line could reach for.
-      log(`Pulling ${origin.url}`);
+      log(origin.sha ? `Pulling ${origin.url} at ${origin.sha.slice(0, 7)}` : `Pulling ${origin.url}`);
       const target = origin.token ? authenticatedCloneUrl(origin.url, origin.token) : origin.url;
-      await run("git", ["clone", "--depth", "1", target, dir]);
+      for (const [cmd, args] of cloneCommands(target, dir, origin.sha, origin.url)) await run(cmd, args);
     });
   }
 

--- a/apps/web/test/app-repos.test.ts
+++ b/apps/web/test/app-repos.test.ts
@@ -1,0 +1,170 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { appForPush, linkRepo, refreshRepoName, type Query } from "../lib/app-repos";
+import { cloneCommands } from "../lib/source";
+import { buildStartSql } from "../lib/builds";
+import { fullNameFromUrl } from "../lib/github-repos";
+
+/**
+ * The link a push is matched on, the clone that a matched push produces, and
+ * the row that records it. Each is asserted against its SQL or its argv rather
+ * than against a database, which is what makes them assertable at all.
+ */
+
+function fake(rows: Record<string, unknown>[] = []) {
+  const seen: Array<{ sql: string; params: unknown[] }> = [];
+  const q: Query = async (sql, params) => { seen.push({ sql, params }); return { rows }; };
+  return { q, seen };
+}
+
+const ROW = {
+  slug: "q13fh",
+  installation_id: "155650459",
+  repo_id: "42",
+  repo_full_name: "thebaycloud/bay",
+  branch: "main",
+  auto_deploy: true,
+  connected_at: "2026-08-23T00:00:00.000Z",
+  owner_id: "owner-1",
+  workspace_id: "ws-1",
+  repo_url: "https://github.com/thebaycloud/bay",
+  connected_login: "onlytenders",
+};
+
+/**
+ * bigint arrives from node-postgres as a string. Coerced once, here, so no
+ * caller has to know that — and a caller that compared `"42" === 42` would
+ * simply never ship anything.
+ */
+test("a push target comes back with its bigints as numbers", async () => {
+  const { q } = fake([ROW]);
+  const t = await appForPush(42, "main", q);
+  assert.equal(t?.installationId, 155650459);
+  assert.equal(t?.repoId, 42);
+  assert.equal(t?.slug, "q13fh");
+  assert.equal(t?.connectedLogin, "onlytenders");
+});
+
+test("a push is matched on the repository id and the branch, in that order", async () => {
+  const { q, seen } = fake([ROW]);
+  await appForPush(42, "main", q);
+  assert.deepEqual(seen[0].params, [42, "main"]);
+  assert.match(seen[0].sql, /r\.repo_id = \$1 AND r\.branch = \$2/);
+});
+
+/**
+ * "Nobody connected this" and "somebody connected it and turned it off" are
+ * different answers, and the webhook says which in its response body. A query
+ * that filtered on `auto_deploy` would collapse them and make the switch
+ * impossible to debug from GitHub's Advanced tab.
+ */
+test("a target with auto-deploy off is still returned", async () => {
+  const { q } = fake([{ ...ROW, auto_deploy: false }]);
+  const t = await appForPush(42, "main", q);
+  assert.equal(t?.autoDeploy, false);
+});
+
+test("an impossible repo id never becomes a query", async () => {
+  const { q, seen } = fake([ROW]);
+  for (const [id, branch] of [[0, "main"], [-1, "main"], [1.5, "main"], [42, ""]] as Array<[number, string]>) {
+    assert.equal(await appForPush(id, branch, q), null);
+  }
+  assert.equal(seen.length, 0);
+});
+
+/**
+ * Re-connecting is how a person moves an app to another repository or branch,
+ * and it arrives as the same slug. `auto_deploy` is deliberately not in the
+ * update set: somebody who turned it off has not asked for it back.
+ */
+test("connecting again re-points the link without re-enabling auto-deploy", async () => {
+  const { q, seen } = fake();
+  await linkRepo({ slug: "q13fh", installationId: 1, repoId: 42, repoFullName: "a/b", branch: "main" }, q);
+  assert.match(seen[0].sql, /ON CONFLICT \(slug\) DO UPDATE/);
+  assert.doesNotMatch(seen[0].sql, /auto_deploy/);
+});
+
+test("a rename updates the stored name only when it actually moved", async () => {
+  const { q, seen } = fake();
+  await refreshRepoName(42, "thebaycloud/renamed", q);
+  assert.match(seen[0].sql, /repo_full_name <> \$2/);
+  assert.deepEqual(seen[0].params, [42, "thebaycloud/renamed"]);
+});
+
+const SHA = "9f2c1a4b8e7d6c5b4a3928170615243342516170";
+
+/**
+ * `git clone --branch` takes a branch or a tag and refuses a SHA, so pinning
+ * cannot be a flag on the clone we already make.
+ */
+test("an unpinned clone is exactly the shallow clone it has always been", () => {
+  assert.deepEqual(cloneCommands("https://github.com/a/b.git", "/tmp/d"), [
+    ["git", ["clone", "--depth", "1", "https://github.com/a/b.git", "/tmp/d"]],
+  ]);
+});
+
+test("a pinned clone fetches the commit itself, one commit deep", () => {
+  const cmds = cloneCommands("https://github.com/a/b.git", "/tmp/d", SHA);
+  assert.deepEqual(cmds.map((c) => c[1][0] === "-C" ? c[1][2] : c[1][0]), ["init", "remote", "fetch", "checkout"]);
+  assert.deepEqual(cmds[2][1], ["-C", "/tmp/d", "fetch", "--depth", "1", "origin", SHA]);
+  assert.deepEqual(cmds[3][1], ["-C", "/tmp/d", "checkout", "--detach", "FETCH_HEAD"]);
+});
+
+/**
+ * Four columns that are always null together. A build with no commit must
+ * produce exactly the statement it produced before commits existed — a push
+ * cannot change what an upload records.
+ */
+test("a build with no commit writes the three columns it always did", () => {
+  const q = buildStartSql("run-1", "q13fh", "you");
+  assert.match(q.text, /INSERT INTO builds\(run_id, slug, who\)/);
+  assert.deepEqual(q.values, ["run-1", "q13fh", "you"]);
+});
+
+test("a build caused by a push carries the commit into the row", () => {
+  const q = buildStartSql("run-1", "q13fh", "someone", {
+    sha: SHA, branch: "main", message: "One clock is the clock", author: "Rakhat",
+  });
+  assert.match(q.text, /commit_sha, commit_branch, commit_message, commit_author/);
+  assert.deepEqual(q.values, ["run-1", "q13fh", "someone", SHA, "main", "One clock is the clock", "Rakhat"]);
+});
+
+/**
+ * The URL door still takes GitLab, a self-hosted git and a `file://` path, and
+ * none of those can be connected to a push — so "not a GitHub URL" is a real
+ * answer rather than a failure.
+ */
+test("owner/repo is read out of every shape a GitHub url arrives in", () => {
+  for (const url of [
+    "https://github.com/thebaycloud/bay",
+    "https://github.com/thebaycloud/bay.git",
+    "https://github.com/thebaycloud/bay/",
+    "github.com/thebaycloud/bay",
+    "https://x-access-token:ghs_secret@github.com/thebaycloud/bay.git",
+  ]) {
+    assert.equal(fullNameFromUrl(url), "thebaycloud/bay", url);
+  }
+  for (const url of ["https://gitlab.com/a/b", "file:///tmp/x", "", "https://github.com/thebaycloud"]) {
+    assert.equal(fullNameFromUrl(url), "", url);
+  }
+});
+
+/**
+ * The build context is the whole directory, `.git` included, and a Dockerfile
+ * that says `COPY . .` would copy an installation token into a layer of an
+ * image pushed to a shared repository. The token lives an hour; an image layer
+ * does not.
+ */
+test("a clone with a credential does not leave it in .git/config", () => {
+  const authed = "https://x-access-token:ghs_secret@github.com/a/b.git";
+  const clean = "https://github.com/a/b.git";
+  for (const cmds of [cloneCommands(authed, "/tmp/d", undefined, clean), cloneCommands(authed, "/tmp/d", SHA, clean)]) {
+    const last = cmds[cmds.length - 1];
+    assert.deepEqual(last[1], ["-C", "/tmp/d", "remote", "set-url", "origin", clean]);
+  }
+});
+
+test("a public clone runs exactly the one command it always ran", () => {
+  const url = "https://github.com/a/b.git";
+  assert.equal(cloneCommands(url, "/tmp/d", undefined, url).length, 1);
+});

--- a/apps/web/test/github-connections.test.ts
+++ b/apps/web/test/github-connections.test.ts
@@ -35,7 +35,22 @@ test("recording an installation upserts, so re-installing is not a duplicate", a
   );
   assert.equal(asked.length, 1);
   assert.match(asked[0].sql, /ON CONFLICT \(installation_id\) DO UPDATE/);
-  assert.deepEqual(asked[0].params, [155650459, W, "thebaycloud", "Organization", null]);
+  // The trailing null is `connected_login`, and an organisation is exactly the
+  // case that has none: GitHub does not say which member installed it, so every
+  // push through it answers `someone` rather than a guess.
+  assert.deepEqual(asked[0].params, [155650459, W, "thebaycloud", "Organization", null, null]);
+});
+
+test("a personal installation records the login a push can be compared against", async () => {
+  const { q, asked } = db();
+  await recordInstallation(
+    { installationId: 1, workspaceId: W, accountLogin: "onlytenders", accountType: "User", connectedBy: null, connectedLogin: "onlytenders" },
+    q,
+  );
+  assert.equal(asked[0].params[5], "onlytenders");
+  // COALESCEd, not overwritten: a re-install by somebody else must not erase
+  // the login the first connection recorded.
+  assert.match(asked[0].sql, /connected_login = COALESCE\(EXCLUDED\.connected_login, github_installations\.connected_login\)/);
 });
 
 test("connections come back typed, with the id as a number", async () => {

--- a/apps/web/test/github-import.test.ts
+++ b/apps/web/test/github-import.test.ts
@@ -40,11 +40,11 @@ test("an installation this workspace owns lists its repositories", async () => {
     installationId: 155650459,
     connections: async () => [],
     owns: async () => true,
-    repos: async () => [{ fullName: "thebaycloud/bay", private: true, defaultBranch: "main", pushedAt: null }],
+    repos: async () => [{ id: 1, fullName: "thebaycloud/bay", private: true, defaultBranch: "main", pushedAt: null }],
   });
   assert.equal(r.status, 200);
   assert.deepEqual(r.body, {
-    repos: [{ fullName: "thebaycloud/bay", private: true, defaultBranch: "main", pushedAt: null }],
+    repos: [{ id: 1, fullName: "thebaycloud/bay", private: true, defaultBranch: "main", pushedAt: null }],
   });
 });
 

--- a/apps/web/test/github-push-deploy.test.ts
+++ b/apps/web/test/github-push-deploy.test.ts
@@ -1,0 +1,171 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shipPush, whoPushed, cloneUrlForPush, type ShipDeps } from "../lib/github-deploy";
+import type { Push } from "../lib/github-webhook";
+import type { PushTarget } from "../lib/app-repos";
+
+/**
+ * What a push means. Every branch here is a decision made with no session, no
+ * caller to return an error to, and money on the other side of it — so each one
+ * is asserted directly rather than inferred from a deploy that did or did not
+ * happen.
+ */
+
+const SHA = "9f2c1a4b8e7d6c5b4a3928170615243342516170";
+
+const PUSH: Push = {
+  repoId: 42,
+  repoFullName: "thebaycloud/bay",
+  branch: "main",
+  sha: SHA,
+  message: "One clock is the clock",
+  author: "Rakhat",
+  senderLogin: "onlytenders",
+};
+
+const TARGET: PushTarget = {
+  slug: "q13fh",
+  installationId: 155650459,
+  repoId: 42,
+  repoFullName: "thebaycloud/bay",
+  branch: "main",
+  autoDeploy: true,
+  connectedAt: null,
+  ownerId: "owner-1",
+  workspaceId: "ws-1",
+  repoUrl: "https://github.com/thebaycloud/bay",
+  connectedLogin: "onlytenders",
+};
+
+/** Deps that never touch a database, GitHub or Cloud Run. */
+function deps(over: Partial<ShipDeps> = {}) {
+  const calls: { dispatched: number; statuses: unknown[]; recorded: unknown[]; charged: number } =
+    { dispatched: 0, statuses: [], recorded: [], charged: 0 };
+  const d: Partial<ShipDeps> = {
+    target: async () => TARGET,
+    refreshName: async () => {},
+    plan: async () => ({ locked: false, monthlyBuilds: 100 }),
+    charge: async () => { calls.charged++; return true; },
+    record: async (runId, slug, who, commit) => { calls.recorded.push({ runId, slug, who, commit }); },
+    dispatch: async () => { calls.dispatched++; },
+    status: async (o) => { calls.statuses.push(o); return true; },
+    jobEnabled: true,
+    ...over,
+  };
+  return { d, calls };
+}
+
+test("a push to a connected branch becomes a build", async () => {
+  const { d, calls } = deps();
+  const r = await shipPush(PUSH, d);
+  assert.equal(r.shipped, true);
+  assert.equal(r.shipped && r.slug, "q13fh");
+  assert.equal(calls.dispatched, 1);
+  assert.equal(calls.charged, 1);
+});
+
+test("the build records the commit that caused it", async () => {
+  const { d, calls } = deps();
+  await shipPush(PUSH, d);
+  assert.deepEqual((calls.recorded[0] as { commit: unknown }).commit, {
+    sha: SHA, branch: "main", message: "One clock is the clock", author: "Rakhat",
+  });
+});
+
+/**
+ * The pending status is what makes the commit say something while the build
+ * runs, and it must arrive AFTER the dispatch — a tick on a build that was
+ * refused is a lie nothing later comes back to correct.
+ */
+test("a pending status is posted, pointing at the app's own address", async () => {
+  const { d, calls } = deps();
+  await shipPush(PUSH, d);
+  assert.equal(calls.statuses.length, 1);
+  assert.partialDeepStrictEqual(calls.statuses[0], {
+    state: "pending",
+    sha: SHA,
+    fullName: "thebaycloud/bay",
+    slug: "q13fh",
+    targetUrl: "https://q13fh.supersonic.cv",
+  });
+});
+
+test("a push nobody connected costs one query and nothing else", async () => {
+  const { d, calls } = deps({ target: async () => null });
+  const r = await shipPush(PUSH, d);
+  assert.deepEqual(r, { shipped: false, reason: "no-app-follows-this-branch" });
+  assert.equal(calls.dispatched, 0);
+  assert.equal(calls.charged, 0);
+  assert.equal(calls.statuses.length, 0);
+});
+
+test("auto-deploy off is a different answer from nobody connected", async () => {
+  const { d, calls } = deps({ target: async () => ({ ...TARGET, autoDeploy: false }) });
+  const r = await shipPush(PUSH, d);
+  assert.deepEqual(r, { shipped: false, reason: "auto-deploy-off", slug: "q13fh" });
+  assert.equal(calls.dispatched, 0);
+  // Not charged: a build that never happened must not be paid for.
+  assert.equal(calls.charged, 0);
+});
+
+test("a reached build limit refuses before anything is dispatched", async () => {
+  const { d, calls } = deps({ charge: async () => false });
+  const r = await shipPush(PUSH, d);
+  assert.deepEqual(r, { shipped: false, reason: "build-limit-reached", slug: "q13fh" });
+  assert.equal(calls.dispatched, 0);
+  assert.equal(calls.statuses.length, 0);
+});
+
+test("a locked account refuses before the meter is touched", async () => {
+  const { d, calls } = deps({ plan: async () => ({ locked: true, monthlyBuilds: 0 }) });
+  const r = await shipPush(PUSH, d);
+  assert.deepEqual(r, { shipped: false, reason: "no-account", slug: "q13fh" });
+  assert.equal(calls.charged, 0);
+});
+
+/**
+ * Without a job to execute in, there is nowhere for the build to run. Refusing
+ * is the only honest answer: letting it through would leave a `pending` status
+ * on a commit that nothing ever comes back to resolve.
+ */
+test("no deploy job means a named refusal, not a hang", async () => {
+  const { d, calls } = deps({ jobEnabled: false });
+  const r = await shipPush(PUSH, d);
+  assert.deepEqual(r, { shipped: false, reason: "deploy-job-disabled", slug: "q13fh" });
+  assert.equal(calls.statuses.length, 0);
+});
+
+test("a dispatch that throws reports `error` on the commit, not `failure`", async () => {
+  const { d, calls } = deps({ dispatch: async () => { throw new Error("the job was not updated"); } });
+  const r = await shipPush(PUSH, d);
+  assert.deepEqual(r, { shipped: false, reason: "dispatch-failed", slug: "q13fh" });
+  assert.partialDeepStrictEqual(calls.statuses[0], { state: "error" });
+  assert.match(String((calls.statuses[0] as { description: string }).description), /the job was not updated/);
+});
+
+/**
+ * CONTEXT.md: "When nobody said, the answer is `someone` — never a guess,
+ * because a wrong name here is worse than no name."
+ */
+test("who pushed is a fact or it is `someone`", () => {
+  assert.equal(whoPushed("onlytenders", "onlytenders"), "you");
+  assert.equal(whoPushed("OnlyTenders", "onlytenders"), "you");
+  assert.equal(whoPushed("ilmak1704", "onlytenders"), "someone");
+  // An organisation installation names nobody, so every org push is `someone`.
+  assert.equal(whoPushed("onlytenders", null), "someone");
+  assert.equal(whoPushed("", "onlytenders"), "someone");
+});
+
+test("an org push is recorded as `someone` even when the pusher connected it", async () => {
+  const { d, calls } = deps({ target: async () => ({ ...TARGET, connectedLogin: null }) });
+  await shipPush(PUSH, d);
+  assert.equal((calls.recorded[0] as { who: string }).who, "someone");
+});
+
+/**
+ * Built from the name in THIS push, so a repository renamed in GitHub is cloned
+ * under its new name on the very next push rather than one push later.
+ */
+test("the clone url comes from the push, not from the stored column", () => {
+  assert.equal(cloneUrlForPush("thebaycloud/renamed"), "https://github.com/thebaycloud/renamed.git");
+});

--- a/apps/web/test/github-repos.test.ts
+++ b/apps/web/test/github-repos.test.ts
@@ -31,12 +31,14 @@ function deps(pages: unknown[][], token = "ghs_tok"): ReposDeps & { calls: strin
 
 test("repositories come back with the fields the picker renders", async () => {
   const d = deps([[{
-    full_name: "thebaycloud/bay", private: true,
+    id: 1030493218, full_name: "thebaycloud/bay", private: true,
     default_branch: "main", pushed_at: "2026-08-22T10:00:00Z",
   }]]);
   const repos = await listRepos(155650459, d);
+  // The id rides along because a push is matched on it, not on the name — which
+  // is what makes a connection survive somebody renaming their repository.
   assert.deepEqual(repos, [{
-    fullName: "thebaycloud/bay", private: true,
+    id: 1030493218, fullName: "thebaycloud/bay", private: true,
     defaultBranch: "main", pushedAt: "2026-08-22T10:00:00Z",
   }]);
 });
@@ -46,8 +48,8 @@ test("every page is fetched, not just the first", async () => {
   // first page is the bug that produces "I can't see my repository" for exactly
   // the accounts that have the most of them.
   const d = deps([
-    Array.from({ length: 100 }, (_, i) => ({ full_name: `o/r${i}`, private: true, default_branch: "main", pushed_at: null })),
-    Array.from({ length: 30 }, (_, i) => ({ full_name: `o/s${i}`, private: true, default_branch: "main", pushed_at: null })),
+    Array.from({ length: 100 }, (_, i) => ({ id: i + 1, full_name: `o/r${i}`, private: true, default_branch: "main", pushed_at: null })),
+    Array.from({ length: 30 }, (_, i) => ({ id: 1000 + i, full_name: `o/s${i}`, private: true, default_branch: "main", pushed_at: null })),
   ]);
   const repos = await listRepos(1, d);
   assert.equal(repos.length, 130);

--- a/apps/web/test/github-webhook.test.ts
+++ b/apps/web/test/github-webhook.test.ts
@@ -1,0 +1,137 @@
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { verifySignature, webhookConfigured, readPush } from "../lib/github-webhook";
+
+/**
+ * The signature is the entire security boundary of `/api/github/webhook`, and
+ * `readPush` is what stops an ordinary thing done to a repository — a tag, a
+ * branch deleted — from becoming a build.
+ *
+ * Both are pure, so both are asserted here rather than through a Request.
+ */
+
+const SECRET = "a".repeat(64);
+const sign = (body: string, key = SECRET) =>
+  "sha256=" + createHmac("sha256", key).update(body, "utf8").digest("hex");
+
+beforeEach(() => { process.env.GH_WEBHOOK_SECRET = SECRET; });
+
+test("a body signed with our secret verifies", () => {
+  const body = JSON.stringify({ ref: "refs/heads/main" });
+  assert.equal(verifySignature(body, sign(body)), true);
+});
+
+test("a body signed with a different secret does not", () => {
+  const body = JSON.stringify({ ref: "refs/heads/main" });
+  assert.equal(verifySignature(body, sign(body, "b".repeat(64))), false);
+});
+
+test("one changed byte in the body breaks it", () => {
+  const body = JSON.stringify({ ref: "refs/heads/main" });
+  const header = sign(body);
+  assert.equal(verifySignature(body + " ", header), false);
+});
+
+/**
+ * Every malformed header is a refusal, never a throw. `timingSafeEqual` rejects
+ * buffers of unequal length by raising, so a short header would otherwise be a
+ * 500 — the route answering "we broke" to something it should simply refuse.
+ */
+test("a malformed signature header is refused, not raised", () => {
+  const body = "{}";
+  for (const header of ["", "sha256=", "sha256=abc", "deadbeef", "sha1=" + "0".repeat(40), null, undefined]) {
+    assert.equal(verifySignature(body, header), false, `accepted ${JSON.stringify(header)}`);
+  }
+});
+
+test("with no secret configured nothing verifies and nothing claims to be configured", () => {
+  delete process.env.GH_WEBHOOK_SECRET;
+  const body = "{}";
+  assert.equal(webhookConfigured(), false);
+  assert.equal(verifySignature(body, sign(body)), false);
+});
+
+const SHA = "9f2c1a4b8e7d6c5b4a3928170615243342516170";
+
+function push(over: Record<string, unknown> = {}) {
+  return {
+    ref: "refs/heads/main",
+    after: SHA,
+    repository: { id: 42, full_name: "thebaycloud/bay" },
+    head_commit: { message: "One clock is the clock\n\nand a body nobody renders", author: { name: "Rakhat" } },
+    sender: { login: "onlytenders" },
+    ...over,
+  };
+}
+
+test("an ordinary push to a branch is readable", () => {
+  const r = readPush(push());
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.ok && r.push, {
+    repoId: 42,
+    repoFullName: "thebaycloud/bay",
+    branch: "main",
+    sha: SHA,
+    message: "One clock is the clock",
+    author: "Rakhat",
+    senderLogin: "onlytenders",
+  });
+});
+
+test("a branch name with slashes survives intact", () => {
+  const r = readPush(push({ ref: "refs/heads/release/2026-08" }));
+  assert.equal(r.ok && r.push.branch, "release/2026-08");
+});
+
+/**
+ * Each of these is a normal thing to do to a repository, so each is a named
+ * reason rather than an error — the route puts it in a 200 body and GitHub's
+ * Advanced tab shows it.
+ */
+test("everything that is not a shippable push says why", () => {
+  const cases: Array<[Record<string, unknown>, string]> = [
+    [{ ref: "refs/tags/v1.0.0" }, "not-a-branch"],
+    [{ ref: "" }, "not-a-branch"],
+    [{ ref: "refs/heads/" }, "not-a-branch"],
+    [{ deleted: true }, "branch-deleted"],
+    [{ after: "0".repeat(40) }, "branch-deleted"],
+    [{ after: "" }, "branch-deleted"],
+    [{ after: "not-a-sha" }, "no-commit"],
+    [{ repository: {} }, "no-repository"],
+    [{ repository: { id: 0, full_name: "x/y" } }, "no-repository"],
+  ];
+  for (const [over, reason] of cases) {
+    const r = readPush(push(over));
+    assert.equal(r.ok, false, `shipped ${JSON.stringify(over)}`);
+    assert.equal(!r.ok && r.reason, reason, `wrong reason for ${JSON.stringify(over)}`);
+  }
+});
+
+test("an empty payload is a refusal rather than a crash", () => {
+  for (const p of [null, undefined, {}, "", 7]) {
+    const r = readPush(p);
+    assert.equal(r.ok, false);
+  }
+});
+
+/**
+ * The author is the person who WROTE the commit, and the sender is whoever
+ * pushed it. On a merge queue or a rebase-and-merge those differ, and the
+ * timeline should show the writer while "who did it" compares the pusher.
+ */
+test("author and sender are kept apart", () => {
+  const r = readPush(push({
+    head_commit: { message: "x", author: { name: "Ilmak" } },
+    sender: { login: "onlytenders" },
+  }));
+  assert.equal(r.ok && r.push.author, "Ilmak");
+  assert.equal(r.ok && r.push.senderLogin, "onlytenders");
+});
+
+test("a commit with no name falls back to the author's username, then to nothing", () => {
+  const named = readPush(push({ head_commit: { message: "x", author: { username: "onlytenders" } } }));
+  assert.equal(named.ok && named.push.author, "onlytenders");
+  const bare = readPush(push({ head_commit: {} }));
+  assert.equal(bare.ok && bare.push.author, "");
+});


### PR DESCRIPTION
Phase two of GitHub CD. Phase one could connect an account and clone a private repository on request; **nothing happened when you pushed**. Now a push to the branch an app follows builds it, and the commit says how it went.

## What lands

- **`app_repos`** (`db/033`) — which repository and branch one app follows, matched on `repo_id` so a rename does not break it. `auto_deploy` defaults on.
- **`/api/github/webhook`** — HMAC over the raw body is the entire security boundary; exempt from the cookie gate beside Stripe's. Every no-op answers **200 with a named reason**, so GitHub's *Advanced* tab explains itself.
- **The dispatch** ends in the same `createRun` → `startDeployRun` pair `/api/deploy` uses — one path, one place to get the quota, the supersede and the outcome right.
- **Pinned clones.** `git clone --branch` refuses a SHA, so a pinned fetch is init / remote add / `fetch --depth 1 <sha>` / `checkout --detach FETCH_HEAD`. Still one commit of bytes.
- **Commit statuses** — `pending` at dispatch, `success`/`failure` from the same `finally` that closes the build row. Best-effort by contract: a deploy that worked is never reported as failed because GitHub would not take a status.
- **UI** — `/new` shows the branch that will ship on each repository row (still one click to deploy); the app's Source panel changes the branch, pauses shipping, or disconnects.

## Found on the way

The clone left its URL as `origin`, and for a private repository that URL carries an installation token. `.git` is excluded from nothing — the build context is the whole directory — so `COPY . .` copies the token into a layer of an image pushed to a shared repository. The remote is now rewritten to the clean URL after every authenticated fetch.

## Still dark until a human acts

Production runs GitHub App `the-bay-cloud` (4680812), which is **subscribed to no events** and holds **no `statuses: write`**. Nothing here fires until the App is switched to `baycloudcd` (4672355), which already carries both — that needs a private key generated in GitHub's UI, three new Secret Manager versions, and the slug swapped in `lib/github-import.ts`.

## Verification

- `db/033` is **already applied to production** — additive and idempotent, and the running code is unaffected by it.
- Tests: **1470 / 1477**. The seven failures are all in `deploy-pipeline` and reproduce unchanged on `e14092f`, the commit production is running; 37 tests added here, all passing.
- `npm run build` clean; `/api/github/webhook` present in the route table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUYPQ1Gwkx8JrmJDQCLf14