### PR TITLE
The App a person installs is the one that can hear a push

### DIFF
--- a/apps/web/lib/github-import.ts
+++ b/apps/web/lib/github-import.ts
@@ -13,10 +13,21 @@ import type { Repo } from "./github-repos";
  * second half of the answer to a question the list itself provokes.
  */
 
+/**
+ * The App, named once.
+ *
+ * `baycloudcd` and not `the-bay-cloud`, which is what shipped in phase one and
+ * is being retired. The two differ in the only ways that matter to a push:
+ * `the-bay-cloud` is subscribed to NO events and holds no `statuses: write`, so
+ * nothing it is installed on can ever ship on a push or report an outcome.
+ *
+ * These two constants are the only place the App is named in code. Everything
+ * else follows from the credentials, which name it by id.
+ */
 /** Where a person goes to connect an account for the first time. */
-export const INSTALL_URL = "https://github.com/apps/the-bay-cloud/installations/new";
+export const INSTALL_URL = "https://github.com/apps/baycloudcd/installations/new";
 /** Where a person goes to change which repositories we can see. */
-export const CONFIGURE_URL = "https://github.com/apps/the-bay-cloud/installations/select_target";
+export const CONFIGURE_URL = "https://github.com/apps/baycloudcd/installations/select_target";
 
 export interface ImportDeps {
   workspaceId: string;

--- a/apps/web/test/github-import.test.ts
+++ b/apps/web/test/github-import.test.ts
@@ -116,6 +116,12 @@ test("the configure link ships with the list, not only with the failure", async 
     connections: async () => [], owns: async () => true, repos: async () => [],
   });
   const body = r.body as { installUrl: string; configureUrl: string };
-  assert.match(body.installUrl, /^https:\/\/github\.com\/apps\/the-bay-cloud\//);
-  assert.match(body.configureUrl, /^https:\/\/github\.com\/apps\/the-bay-cloud\//);
+  assert.equal(body.installUrl, INSTALL_URL);
+  assert.equal(body.configureUrl, CONFIGURE_URL);
+  // The shape, asserted once. The App's slug is named in lib/github-import.ts
+  // and must not be named again here — a test that hardcodes it becomes the
+  // second place to edit when the App changes, and the one nobody remembers.
+  for (const u of [INSTALL_URL, CONFIGURE_URL]) {
+    assert.match(u, /^https:\/\/github\.com\/apps\/[\w.-]+\/installations\/[\w_]+$/);
+  }
 });


### PR DESCRIPTION
Follow-up to #20, and **urgent**: production now holds `baycloudcd`'s credentials while `main` still points the *Connect* button at `the-bay-cloud`. Anyone connecting right now installs the wrong App and the callback refuses it with `no-installation`.

Phase one shipped against **`the-bay-cloud` (4680812)**, which cannot do the thing phase two exists for — it is subscribed to **no events** and holds **no `statuses: write`**. Every line of the webhook, the dispatch and the commit status would have been correct and dark.

**`baycloudcd` (4672355)** already carries both (`events: ["push"]`, `statuses: write`), and its webhook already pointed at `/api/github/webhook`. It had **no webhook secret at all** — one is set now, and lives in exactly two places: the App, and `gh-webhook-secret` in Secret Manager.

## Already done outside this diff

- `gh-app-id` → `4672355`, `gh-app-private-key` → the new PEM, `gh-webhook-secret` → a fresh 32-byte secret. All three are **new versions**, and all three are mounted at `latest` on the control plane, the worker and the job — so no `gcloud run` edit was needed, and the revision that was running kept the old credentials in memory until it was replaced. No window in which half the platform is one App and half is the other.
- Verified with the new key: `GET /app` → 200, `events: ["push"]`, `permissions: {contents: read, metadata: read, statuses: write}`, hook URL correct, `installations: 0`.

## In this diff

The slug, in the two constants that are the only place the App is named in code. The import test stops naming it a second time — it hardcoded the slug, which made it the place nobody remembers to edit; it asserts the exported constants and the shape of the URL instead.

## Still to do after merge

Delete the `github_installations` row for the old App (155650459). An installation that cannot mint is worse than none: the import screen offers an account whose repositories never load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUYPQ1Gwkx8JrmJDQCLf14