### PR TITLE
Finishing an install lands on a 404

### DIFF
--- a/apps/web/app/api/github/callback/route.ts
+++ b/apps/web/app/api/github/callback/route.ts
@@ -1,0 +1,30 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * The other name GitHub might send somebody back to after installing.
+ *
+ * An App's *Setup URL* is a field in GitHub's own UI, readable through no API
+ * and editable only by an owner of the account that owns the App. Ours was
+ * written before the route was named, and points here — at `/api/github/callback`,
+ * which the shipped code calls `/api/github/setup`. The result is a person who
+ * finishes installing and lands on a 404 with an installation that exists and is
+ * bound to nothing.
+ *
+ * Fixed here rather than in that field, deliberately. The field cannot be read
+ * back to check, it cannot be changed by anyone on this side, and a platform
+ * whose connect flow depends on a setting nobody here can see is one that breaks
+ * again the next time an App is created. Answering at both names costs three
+ * lines and removes the dependency.
+ *
+ * A redirect rather than a second copy of the handler: the binding is written in
+ * exactly one place, and the query string — `installation_id`, `setup_action` —
+ * is carried across untouched, along with the session cookie the setup route
+ * needs and that a same-origin redirect keeps.
+ */
+export async function GET(req: Request): Promise<Response> {
+  const from = new URL(req.url);
+  const to = new URL("/api/github/setup", from.origin);
+  to.search = from.search;
+  return Response.redirect(to.toString(), 307);
+}

--- a/apps/web/test/github-callback-alias.test.ts
+++ b/apps/web/test/github-callback-alias.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { GET } from "../app/api/github/callback/route";
+
+/**
+ * A person who finishes installing lands wherever the App's *Setup URL* says,
+ * and that field is readable through no API and editable only by an owner of
+ * the account that owns the App. Ours names `/api/github/callback`; the shipped
+ * route is `/api/github/setup`. Until this alias existed the install finished on
+ * a 404, with an installation that existed and was bound to nothing.
+ */
+
+test("the callback carries the installation across to the route that binds it", async () => {
+  const res = await GET(new Request("https://app.supersonic.cv/api/github/callback?installation_id=156002778&setup_action=install"));
+  assert.equal(res.status, 307);
+  const to = new URL(res.headers.get("location") ?? "");
+  assert.equal(to.pathname, "/api/github/setup");
+  // Every parameter, untouched. `setup_action` is not read today and is carried
+  // anyway: dropping a field here would be a decision made in the wrong module.
+  assert.equal(to.searchParams.get("installation_id"), "156002778");
+  assert.equal(to.searchParams.get("setup_action"), "install");
+});
+
+test("it stays on the origin it was called on", async () => {
+  // Local development and the preview hosts are not app.supersonic.cv, and a
+  // redirect to a hardcoded host would send a developer's session to production.
+  const res = await GET(new Request("http://localhost:3000/api/github/callback?installation_id=1"));
+  assert.equal(new URL(res.headers.get("location") ?? "").origin, "http://localhost:3000");
+});
+
+test("no query at all is still a redirect, not a crash", async () => {
+  const res = await GET(new Request("https://app.supersonic.cv/api/github/callback"));
+  assert.equal(res.status, 307);
+  assert.equal(new URL(res.headers.get("location") ?? "").pathname, "/api/github/setup");
+});


### PR DESCRIPTION
Installing the App works, and then the person lands on a **404** with an installation that exists and is bound to nothing. Reproduced in production minutes ago: installation `156002778` on `thebaycloud` was created, GitHub delivered `installation.created` to the webhook (200), and the browser was sent to a page that does not exist.

The cause is the App's **Setup URL** — a field in GitHub's own UI. Ours names `/api/github/callback`, from the design that predates the shipped code, which calls the route `/api/github/setup`.

Fixing the field would work once. It is readable through no API, editable only by an owner of the account that owns the App — for `thebaycloud` that is two people, neither of whom is necessarily whoever creates the next App — and unverifiable from this side afterwards. So the platform answers at both names instead: a 307 carrying the query string, and the session cookie a same-origin redirect keeps, to the one route that writes the binding. No second copy of the handler.

Three tests: the parameters survive, the redirect stays on the origin it was called on (a hardcoded host would send a developer's local session to production), and no query at all is still a redirect rather than a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUYPQ1Gwkx8JrmJDQCLf14