### PR TITLE
Connecting the wrong account was a dead end

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -663,6 +663,10 @@ a.shelf-host:hover { color: var(--ink); text-decoration: underline; text-underli
 .door { display: inline-flex; align-items: center; height: 30px; padding: 0 14px; font-size: 13px; font-weight: 500; color: var(--ink-2); background: none; border: none; border-radius: calc(var(--r) - 4px); transition: background .14s var(--ease), color .14s var(--ease); }
 .door:hover { color: var(--ink); }
 .door.on { background: var(--white); color: var(--ink); box-shadow: 0 1px 2px rgb(0 0 0 / .08); }
+/* One of the chips is a link out to GitHub rather than a tab. It sits in the
+   same row and must read as one, so it loses the underline every other anchor
+   on this page keeps. */
+a.door { text-decoration: none; }
 .repo { display: flex; align-items: stretch; border: 1px solid var(--line-2); background: var(--card); margin-bottom: 14px; border-radius: var(--r); }
 .repo .pre { display: flex; align-items: center; padding: 0 12px; font-family: var(--mono); font-size: 13px; color: var(--faint); border-right: 1px solid var(--line); white-space: nowrap; }
 .repo input { flex: 1; border: none; background: none; outline: none; font-family: var(--mono); font-size: 14px; color: var(--ink); padding: 12px; }

--- a/apps/web/app/new/page.tsx
+++ b/apps/web/app/new/page.tsx
@@ -384,17 +384,29 @@ export default function NewApp() {
                       </>
                     ) : (
                       <>
-                        {ghConnections.length > 1 && (
-                          <div className="doors" style={{ marginBottom: 10 }}>
-                            {ghConnections.map((c) => (
-                              <button
-                                key={c.installationId}
-                                className={"door" + (ghInstallation === c.installationId ? " on" : "")}
-                                onClick={() => setGhInstallation(c.installationId)}
-                              >{c.accountLogin}</button>
-                            ))}
-                          </div>
-                        )}
+                        {/* The accounts, and the way to add one.
+                            
+                            Shown at ONE account as well as at several, which it
+                            was not: a person who connected the wrong account —
+                            an organisation with one repository instead of the
+                            personal account with sixty — saw that account's
+                            short list, a link to widen its selection, and no way
+                            at all to connect the right one. The install link
+                            existed only on the screen for somebody with no
+                            connections, which is the one person who does not
+                            need it twice. */}
+                        <div className="doors" style={{ marginBottom: 10 }}>
+                          {ghConnections.map((c) => (
+                            <button
+                              key={c.installationId}
+                              className={"door" + (ghInstallation === c.installationId ? " on" : "")}
+                              onClick={() => setGhInstallation(c.installationId)}
+                            >{c.accountLogin}</button>
+                          ))}
+                          <a className="door" href={ghLinks?.installUrl ?? "#"}>
+                            <Github size={12} />&nbsp;Add an account
+                          </a>
+                        </div>
                         {ghTrouble && <p className="lead" style={{ margin: "0 0 10px", fontSize: 13 }}>{ghTrouble}</p>}
                         {ghRepos === null ? (
                           <p className="lead" style={{ margin: "0 0 14px", fontSize: 13 }}>Reading what you picked…</p>


### PR DESCRIPTION
The GitHub door offered **Connect GitHub** only to somebody with *no* connections — the one person who does not need it a second time. Connect the wrong account and the screen showed that account's repositories, a link to widen its selection, and **no way at all** to reach the account you meant.

Hit for real today: the App went on the organisation, which owns one repository, while the sixty-nine the person wanted were on their personal account. Everything worked as designed and the screen said "here is your repository" — true, and not what they were looking for.

An installation belongs to **one account**; that is GitHub's model, not ours. So "any of my repositories" means as many installations as the person has accounts. The account row now always renders — at one connection as well as at several — and carries **Add an account** beside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUYPQ1Gwkx8JrmJDQCLf14