### PR TITLE
A deploy that is running is the whole screen

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1364,3 +1364,87 @@ a.door { text-decoration: none; }
 .dfilm-bar .url { color: var(--live); opacity: 0; transition: opacity .4s var(--ease);
   text-transform: none; letter-spacing: .02em; font-size: 11.5px; }
 .dfilm-bar .url.on { opacity: 1; }
+
+/* ------------------------------------------------------------
+   FULLSCREEN — a deploy running is the whole screen.
+
+   The same treatment the ROOM already gives this film
+   (services/proxy/src/room-page.ts): the picture takes the window and
+   everything the page has to say is written over it, because a deploy is 90
+   seconds of nothing else happening and a 2.40:1 card in a column of white
+   spends the screen on the parts of the page nobody is reading.
+
+   The frame can no longer be assumed here, and that is handled in the film
+   rather than in CSS: `framed()` in ship-it.js holds the HORIZONTAL field each
+   shot was composed with, so a 16:9 window shows more sky and water instead of
+   cropping the bridge and the yard off the sides.
+   ------------------------------------------------------------ */
+/* `overflow: hidden` is structural, not tidiness: this is fixed, so anything
+   inside it that does not fit widens the DOCUMENT instead of the box, and then
+   every `right:` in here is measured off a viewport that is wider than the
+   screen — the name slides off the right edge and the buttons go with it.
+   100dvh rather than 100vh: on a phone the toolbars come and go, and vh is the
+   tallest of those states, which puts the stage bar under the browser's own
+   chrome for the first half of the deploy. */
+.cinema { position: fixed; inset: 0; z-index: 50; background: #0a100e; height: 100dvh; overflow: hidden; }
+/* absolute, not fixed: `.cinema` is the fixed box, and the words below have to
+   stack over the picture inside it. */
+.dfilm.full { position: absolute; inset: 0; border: 0; border-radius: 0; background: #0a100e; }
+.dfilm.full .dfilm-frame { position: absolute; inset: 0; }
+/* The holder the film appends its canvas into has to have a height of its own.
+   It never needed one in the card: the canvas sizes itself with
+   `aspect-ratio`, which resolves against an auto-height parent perfectly well.
+   `height:100%` does not — it resolves to auto, and the picture would sit in a
+   band across the top of the window with dead space under it. */
+.dfilm.full .dfilm-canvas { position: absolute; inset: 0; }
+/* `contain`, and it is not decoration: the film sizes its own drawing buffer
+   to this box, so the fit is normally an identity — but an older film still
+   frames its buffer at 2.40:1, and stretched to a 16:9 window that is the
+   whole picture squashed. Contained, it letterboxes instead. */
+.dfilm.full .dfilm-frame canvas { width: 100%; height: 100%; aspect-ratio: auto; object-fit: contain; }
+/* The two bars were the cinema the card sat in. There is no card now. */
+.dfilm.full .dfilm-bar { display: none; }
+.dfilm.full .dfilm-slate { left: 22px; top: 18px; }
+.dfilm.full .dfilm-stagebar { left: 22px; right: 22px; bottom: 18px; }
+.dfilm.full .dfilm-fallback { position: absolute; left: 0; right: 0; top: 50%; transform: translateY(-50%); }
+
+/* what the page has to say, over the picture.
+   Top RIGHT, not spread across the top: the film puts its slate in the top
+   left corner and a name at the left edge would print over it. */
+.cinema-bar { position: absolute; right: 22px; top: 18px; display: flex; gap: 12px; align-items: baseline;
+  font-family: var(--mono); font-size: 12px; color: rgba(233,239,235,.55); pointer-events: none;
+  text-shadow: 0 1px 3px rgba(0,0,0,.75); }
+.cinema-bar .nm { color: #e9efeb; }
+.cinema-bar .clock { font-variant-numeric: tabular-nums; }
+/* The build's own words: the last six lines, which is what fits without the
+   log becoming the page. Above the film's stage bar, not over it. */
+.cinema-log { position: absolute; left: 22px; bottom: 52px; width: min(62ch, 52vw);
+  display: flex; flex-direction: column; font-family: var(--mono); font-size: 11.5px; line-height: 1.7;
+  color: rgba(233,239,235,.60); text-shadow: 0 1px 3px rgba(0,0,0,.75); pointer-events: none; }
+.cinema-log > div { display: flex; gap: 8px; min-width: 0; }
+.cinema-log .k { flex: none; width: 1em; color: rgba(233,239,235,.34); }
+.cinema-log .k.g { color: #4ec585; }
+.cinema-log .k.a { color: #7fa8d8; }
+.cinema-log .m { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* The address is the film's own endcard, bottom centre. These are what to do
+   about it, and they clear the stage bar on a short window. */
+.cinema-acts { position: absolute; left: 50%; bottom: max(64px, 7%); transform: translateX(-50%);
+  display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; max-width: calc(100vw - 44px); }
+/* Under the endcard is where these belong, and there is room for them there on
+   a wide window. On a narrower one the log — `min(62ch, 52vw)` — reaches the
+   middle of the screen, and a long line would run under the buttons, so they
+   go to the corner the stage bar leaves empty instead. */
+@media (max-width: 1200px) {
+  .cinema-acts { left: auto; right: 22px; bottom: 44px; transform: none; justify-content: flex-end; }
+}
+@media (max-width: 640px) {
+  .cinema-log { width: auto; right: 22px; }
+  /* The film's own caption and the app's name are both one line across the top
+     of a screen that has room for one of them. The name is the one a person
+     came for. */
+  .dfilm.full .dfilm-slate { display: none; }
+  /* A phone has one column and the deploy is over: the address on the endcard
+     and what to do about it are the screen. The log has had its whole run. */
+  .cinema.done .cinema-log { display: none; }
+  .cinema-acts { left: 22px; right: 22px; bottom: 44px; justify-content: center; }
+}

--- a/apps/web/app/new/page.tsx
+++ b/apps/web/app/new/page.tsx
@@ -342,6 +342,15 @@ export default function NewApp() {
 
   const busy = phase === "deploying";
 
+  /* Nothing scrolls behind the cinema. The overlay covers the window, so a
+     wheel over it would otherwise move a page nobody can see. */
+  useEffect(() => {
+    if (phase !== "deploying" && phase !== "done") return;
+    const was = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = was; };
+  }, [phase]);
+
   return (
     <div className="shell">
       <header className="topbar">
@@ -561,17 +570,21 @@ export default function NewApp() {
               </div>
             )}
 
-            {(phase === "deploying" || phase === "done" || phase === "error") && (
+            {/* A deploy that is RUNNING is the whole screen — see `cinema` at
+                the bottom of this file. What is left here is the wreckage of one
+                that failed: the words, without the picture. The film's break and
+                its repair drone are worth watching while the agent is actually
+                working, which is in the cinema; by the time this screen is up the
+                story is over and the fix below is what has to be read. */}
+            {phase === "error" && (
               <div className="stage">
                 <div className="stage-head">
                   <span className="t">
-                    <span className="mono">{phase === "error" ? "✕" : "▸"}</span>
-                    {phase === "done" ? `Deployed ${slug}` : phase === "error" ? "Deploy failed" : `Deploying ${slug || "…"}`}
+                    <span className="mono">✕</span>
+                    Deploy failed
                   </span>
                   <span className="clock">{elapsed}s</span>
                 </div>
-
-                <DeployFilm drive={film} elapsed={elapsed} />
 
                 {detected && (
                   <div className="detected">
@@ -595,20 +608,6 @@ export default function NewApp() {
                     );
                   })}
                   {busy && <div className="ln show"><span className="arrow">▸</span><span className="tx muted">working…</span></div>}
-                </div>
-              </div>
-            )}
-
-            {phase === "done" && (
-              <div className="success">
-                <div className="success-live"><span className="d" />Live</div>
-                <div className="big">{liveUrl.replace(/^https?:\/\//, "")}</div>
-                <div className="u muted">deployed in {elapsed}s · Cloud Run · us-central1</div>
-                <div className="acts">
-                  <a className="btn" href={liveUrl} target="_blank" rel="noreferrer">Visit<ArrowRight size={13} /></a>
-                  
-                    <Link href={`/apps/${slug}`} className="btn primary">Open cockpit<ArrowRight size={13} /></Link>
-                  
                 </div>
               </div>
             )}
@@ -655,6 +654,54 @@ export default function NewApp() {
           </div>
         </div>
       </div>
+
+      {/* THE CINEMA — a deploy that is running, at the size it deserves.
+
+          A container deploy is 90 seconds during which this page has exactly
+          one thing on it worth looking at, and it was a 2.40:1 card in the
+          middle of a column of white. It gets the window now, the same way the
+          room does at the app's own address, and everything the page was
+          saying underneath is said over the picture: the name and the clock in
+          one corner, the build's last six lines in the other.
+
+          Fixed, and mounted HERE rather than inside `.newflow` — an ancestor
+          with a transform on it (the reveal animation) is a containing block
+          for `position: fixed`, and this would have been fixed to that column
+          rather than to the window.
+
+          It stays up when the deploy lands, because the ending is the point:
+          the sun comes up, she sails under the bridge, and the address is the
+          film's own endcard. These are what to do about it. */}
+      {(phase === "deploying" || phase === "done") && (
+        <div className={"cinema" + (phase === "done" ? " done" : "")}>
+          <DeployFilm drive={film} elapsed={elapsed} full />
+          <div className="cinema-bar">
+            <span className="nm">{slug || "…"}</span>
+            <span className="clock">{elapsed}s</span>
+          </div>
+          <div className="cinema-log">
+            {logs.slice(-6).map((l, i) => {
+              const ok = /^(Detected|Provision|Live at|Injecting|Agent fixed)/.test(l);
+              const agent = /^agent · /.test(l);
+              return (
+                <div key={`${i}-${l}`}>
+                  <span className={"k" + (ok ? " g" : agent ? " a" : "")}>{ok ? "✓" : agent ? "◆" : "·"}</span>
+                  <span className="m">{l}</span>
+                </div>
+              );
+            })}
+            {busy && <div><span className="k">▸</span><span className="m">working…</span></div>}
+          </div>
+          {phase === "done" && (
+            <div className="cinema-acts">
+              <a className="btn" href={liveUrl} target="_blank" rel="noreferrer">Visit<ArrowRight size={13} /></a>
+              <Link href={`/apps/${slug}`} className="btn primary">Open cockpit<ArrowRight size={13} /></Link>
+              {/* The way out of a picture that has finished playing. */}
+              <button className="btn" onClick={reset}><RotateCcw size={13} />Deploy another</button>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Always dismissable: there is no state a person can be in where the
           only thing behind this modal is a locked account. Free is always

--- a/apps/web/components/DeployFilm.tsx
+++ b/apps/web/components/DeployFilm.tsx
@@ -31,7 +31,7 @@ import { railIndex, type FilmDrive } from "@/lib/deploy-film";
  * effect, so nothing about the deploy page's own weight changes for a person
  * who never deploys.
  */
-export function DeployFilm({ drive, elapsed }: { drive: FilmDrive; elapsed: number }) {
+export function DeployFilm({ drive, elapsed, full = false }: { drive: FilmDrive; elapsed: number; full?: boolean }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const film = useRef<FilmHandle | null>(null);
   // The latest instruction, kept in a ref as well as in props: the module
@@ -115,8 +115,12 @@ export function DeployFilm({ drive, elapsed }: { drive: FilmDrive; elapsed: numb
 
   useEffect(apply, [drive, elapsed]);
 
+  // `full` is the shape, not a second film: the picture takes the window and
+  // the card's own chrome goes. It changes a class, so a deploy that is already
+  // running is not remounted — the film watches its canvas with a
+  // ResizeObserver and re-frames itself for whatever box it ends up in.
   return (
-    <div className="dfilm" ref={rootRef}>
+    <div className={full ? "dfilm full" : "dfilm"} ref={rootRef}>
       <div className="dfilm-bar top">
         <span data-el="tagLane">deploying…</span>
         <span className="sp" />


### PR DESCRIPTION
The deploy film was already fullscreen in the **room** — the waiting page the proxy serves at the app's own address — and it was never fullscreen on **/new**, which is where a person watches their first deploy. There it was a 720px 2.40:1 card in a column of white, with ninety seconds of nothing else happening on the page around it.

It gets the window now, in the treatment the room already uses: the picture takes the viewport, and everything the page had to say is written over it — the app's name and the deploy's clock in one corner, the build's last six lines in the other, the film's own slate and stage bar where it puts them.

### What is in here

- `apps/web/app/new/page.tsx` — a `.cinema` overlay while the deploy is `deploying` or `done`. Mounted at the component root, **not** inside `.newflow`: that column carries a transform in its reveal animation, and a transform is a containing block for `position: fixed`.
- `apps/web/components/DeployFilm.tsx` — a `full` prop. It is a class, not a second film, so a running deploy is not remounted; the film re-frames itself off its own ResizeObserver.
- `apps/web/app/globals.css` — `.cinema` and `.dfilm.full`. The canvas holder gets a height of its own (`aspect-ratio` resolves against an auto-height parent, `height:100%` does not, and the picture would sit in a band across the top); `object-fit: contain` on the canvas; `overflow: hidden` on `.cinema`, because anything inside a fixed box that does not fit widens the *document* instead and then every `right:` is measured off a viewport wider than the screen.

### The two endings

`done` stays in the cinema, because the ending is the point — the sun comes up, she sails under the gate, and the address is the film's own endcard with Visit / Open cockpit / Deploy another under it.

`error` leaves it. The break and the repair drone are worth watching while the agent is actually working, but by the time the failure screen is up the story is over and the fix prompt is what has to be read.

### Verification

Headless render of the real markup and CSS at 1440×900, 900×1200 and a phone width: the picture fills the window, `framed()` spends the extra height on sky rather than cropping the bridge and the yard off the sides, the words clear each other and the stage bar, and the actions move to the corner the stage bar leaves empty once the log reaches the middle of the screen.

`tsc --noEmit` clean; `test/film-frame.test.ts` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FZyWSgqnaZoiT4Hiw4XN8