### PR TITLE
A page that hands out keys shows the keys it already handed out

### DIFF
--- a/apps/web/app/cli/page.tsx
+++ b/apps/web/app/cli/page.tsx
@@ -1,7 +1,19 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { signOut } from "next-auth/react";
+
+interface Tok { id: string; name: string | null; created_at: string; last_used_at: string | null }
+interface Acct { email: string; name: string | null }
+
+function shortDate(s: string | null): string {
+  if (!s) return "never";
+  try { return new Date(s).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }); }
+  catch { return "—"; }
+}
+
+const line = "1px solid var(--line)";
 
 function CliAuth() {
   const sp = useSearchParams();
@@ -10,6 +22,29 @@ function CliAuth() {
   const [state, setState] = useState<"idle" | "working" | "done" | "error">("idle");
   const [token, setToken] = useState("");
   const [msg, setMsg] = useState("");
+
+  // Who this authorization would attach to, and what is already attached. The
+  // page used to say neither: you pressed Authorize and a token appeared, with
+  // no way to see that the last four machines still hold one — or that you are
+  // signed in as the wrong account.
+  const [acct, setAcct] = useState<Acct | null>(null);
+  const [tokens, setTokens] = useState<Tok[] | null>(null);
+  const [freshId, setFreshId] = useState("");
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  const loadTokens = useCallback(async () => {
+    try {
+      const r = await fetch("/api/cli/token");
+      const d = await r.json();
+      setTokens(d.tokens ?? []);
+    } catch { setTokens([]); }
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/account").then((r) => r.json()).then((d) => { if (d.email) setAcct(d); }).catch(() => {});
+    loadTokens();
+  }, [loadTokens]);
 
   async function authorize() {
     setState("working"); setMsg("");
@@ -26,22 +61,59 @@ function CliAuth() {
         window.location.href = `http://127.0.0.1:${port}/callback?token=${encodeURIComponent(d.token)}`;
         return;
       }
-      setToken(d.token); setState("done");
+      setToken(d.token); setFreshId(d.id); setState("done");
+      loadTokens();
     } catch (e) {
       setMsg(e instanceof Error ? e.message : String(e)); setState("error");
     }
   }
 
+  async function revoke(id: string) {
+    setRevoking(id);
+    try {
+      const r = await fetch(`/api/cli/token?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+      const d = await r.json().catch(() => ({}));
+      // The route answers 200 with `ok:false` for an id that is not yours —
+      // taking that as success would drop the row from the list while the
+      // token kept working, which is the one lie this panel must not tell.
+      if (!r.ok || d.error || d.ok === false) throw new Error(d.error || "couldn't revoke that one");
+      setTokens((t) => (t ?? []).filter((x) => x.id !== id));
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRevoking(null); setConfirmingId(null);
+    }
+  }
+
+  // Signing out from here has to come back here: the CLI is holding a loopback
+  // port open, and dropping the visitor on the dashboard would strand it until
+  // it times out.
+  async function switchAccount() {
+    await signOut({ redirect: false });
+    const back = window.location.pathname + window.location.search;
+    window.location.href = `/login?callbackUrl=${encodeURIComponent(back)}`;
+  }
+
   // position:relative + z-index:1 lifts this above the fixed graph-paper grid
   // (body::before, z-index:0), which otherwise paints over the content.
   return (
-    <div style={{ position: "relative", zIndex: 1, maxWidth: 480, margin: "14vh auto", padding: "0 24px", fontFamily: "var(--mono, ui-monospace, monospace)" }}>
-      <div style={{ border: "1px solid var(--line)", background: "var(--card)", padding: 30 }}>
+    <div style={{ position: "relative", zIndex: 1, maxWidth: 480, margin: "14vh auto 8vh", padding: "0 24px", fontFamily: "var(--mono, ui-monospace, monospace)" }}>
+      <div style={{ border: line, background: "var(--card)", padding: 30 }}>
         <div style={{ fontSize: 12, letterSpacing: 2, color: "var(--ink-2)", marginBottom: 8 }}>SUPERSONIC / CLI</div>
         <h1 style={{ fontSize: 22, margin: "0 0 12px", color: "var(--ink)" }}>Authorize the CLI</h1>
-        <p style={{ fontSize: 13, lineHeight: 1.6, color: "var(--ink-2)", margin: "0 0 22px" }}>
+        <p style={{ fontSize: 13, lineHeight: 1.6, color: "var(--ink-2)", margin: "0 0 18px" }}>
           This connects <b style={{ color: "var(--ink)" }}>{name}</b> to your Supersonic account so your coding agent can deploy and manage apps from the terminal.
         </p>
+
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12, padding: "10px 12px", border: line, background: "var(--paper)", marginBottom: 22 }}>
+          <span style={{ fontSize: 12, color: "var(--ink-2)" }}>
+            signed in as <b style={{ color: "var(--ink)" }}>{acct?.email ?? "…"}</b>
+          </span>
+          <button onClick={switchAccount}
+            style={{ background: "none", border: "none", padding: 0, fontFamily: "inherit", fontSize: 12, color: "var(--ink-2)", textDecoration: "underline", cursor: "pointer" }}>
+            not you?
+          </button>
+        </div>
 
         {state !== "done" && (
           <button onClick={authorize} disabled={state === "working"}
@@ -62,13 +134,63 @@ function CliAuth() {
         {state === "done" && !port && (
           <div>
             <p style={{ fontSize: 13, marginBottom: 8, color: "var(--ink)" }}>✓ Token created — paste this into your terminal:</p>
-            <code style={{ display: "block", padding: 12, background: "var(--paper)", border: "1px solid var(--line)", wordBreak: "break-all", fontSize: 12, color: "var(--ink)" }}>
+            <code style={{ display: "block", padding: 12, background: "var(--paper)", border: line, wordBreak: "break-all", fontSize: 12, color: "var(--ink)" }}>
               supersonic login --token {token}
             </code>
           </div>
         )}
 
         {state === "error" && <p style={{ fontSize: 13, color: "#e5484d" }}>⚠ {msg}</p>}
+      </div>
+
+      {/* Everything already holding a key to this account. A machine you no
+          longer use, or one you don't recognize, is revoked from here. */}
+      <div style={{ border: line, borderTop: "none", background: "var(--card)", padding: "22px 30px 26px" }}>
+        <div style={{ fontSize: 12, letterSpacing: 1, color: "var(--ink-2)", marginBottom: 14 }}>AUTHORIZED CLIS</div>
+
+        {tokens === null && <div style={{ fontSize: 13, color: "var(--ink-2)" }}>Loading…</div>}
+        {tokens?.length === 0 && (
+          <div style={{ fontSize: 13, color: "var(--ink-2)", lineHeight: 1.6 }}>
+            Nothing is authorized yet — this will be the first.
+          </div>
+        )}
+
+        {tokens?.map((t) => (
+          <div key={t.id} style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 0", borderTop: line }}>
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div style={{ fontSize: 13, color: "var(--ink)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {t.name || "cli"}
+                {t.id === freshId && <span style={{ marginLeft: 8, fontSize: 11, color: "var(--ink-2)" }}>· just now</span>}
+              </div>
+              <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 3 }}>
+                added {shortDate(t.created_at)} · last used {shortDate(t.last_used_at)}
+              </div>
+            </div>
+            {confirmingId === t.id ? (
+              <span style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                <button onClick={() => revoke(t.id)} disabled={revoking === t.id}
+                  style={{ fontFamily: "inherit", fontSize: 12, padding: "5px 10px", border: "1px solid #e5484d", background: "#e5484d", color: "var(--card)", cursor: "pointer" }}>
+                  {revoking === t.id ? "…" : "Revoke"}
+                </button>
+                <button onClick={() => setConfirmingId(null)}
+                  style={{ fontFamily: "inherit", fontSize: 12, padding: "5px 10px", border: line, background: "var(--card)", color: "var(--ink-2)", cursor: "pointer" }}>
+                  Cancel
+                </button>
+              </span>
+            ) : (
+              <button onClick={() => { setConfirmingId(t.id); setMsg(""); }}
+                style={{ flexShrink: 0, fontFamily: "inherit", fontSize: 12, padding: "5px 10px", border: line, background: "var(--card)", color: "var(--ink-2)", cursor: "pointer" }}>
+                Revoke
+              </button>
+            )}
+          </div>
+        ))}
+
+        {tokens && tokens.length > 0 && (
+          <p style={{ fontSize: 11, color: "var(--ink-2)", lineHeight: 1.6, margin: "14px 0 0" }}>
+            Revoking takes effect immediately — that machine&apos;s next command is rejected and it has to sign in again.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -6,16 +6,25 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { Github } from "lucide-react";
 import { Mark } from "@/components/Mark";
+import { isPlatformHost } from "@/lib/roots";
 import { GoogleIcon } from "@/components/BrandIcons";
 
 // The URL to return to after auth — read from ?callbackUrl and validated to be a
-// supersonic.cv address, so we never bounce a user to an attacker-supplied host.
+// host under one of our own roots, so we never bounce a user to an
+// attacker-supplied one. Asked of `rootDomains()` rather than a literal: during
+// the cutover both roots answer, and a literal here would refuse the new one.
+//
+// A same-origin path is allowed too (leading "/" but not "//", which the browser
+// reads as a protocol-relative host): that is how /cli sends you back to the
+// authorization it was in the middle of after you switch accounts, and it is the
+// only form that survives local development, where there is no public root.
 function safeCallback(): string {
   try {
     const cb = new URLSearchParams(window.location.search).get("callbackUrl");
     if (!cb) return "";
+    if (cb.startsWith("/") && !cb.startsWith("//")) return cb;
     const u = new URL(cb);
-    if (u.protocol === "https:" && (u.hostname === "supersonic.cv" || u.hostname.endsWith(".supersonic.cv"))) return cb;
+    if (u.protocol === "https:" && isPlatformHost(u.hostname)) return cb;
   } catch { /* malformed — fall through */ }
   return "";
 }


### PR DESCRIPTION
`/cli` — the page `supersonic login` opens — asked you to attach a machine to an account it never named, minted a token, and ended. It now says which account, what else already holds a token, and lets you take any of them back.


**Before / after, and every check, are in the report:** https://claude.ai/code/artifact/491a10d4-b711-4899-9d11-b49ce5114705

### What it does now

- **signed in as `<email>`** — "attach this machine to your account" is half a question without the account. **not you?** signs out and comes back to *this* authorization with the loopback port intact, instead of dropping you on the dashboard while the terminal waits out its 5-minute timeout.
- **Authorized CLIs** — every token on the account: machine name, when it was added, when it was last used. `never` is its own answer — a CI runner that was authorized once and has not called since.
- **Revoke** on each row, behind an inline confirm.

### No new API, no schema change

`listTokens` / `revokeToken` have existed since the CLI did, and `/settings` already calls them. This page simply never reached for them.

One edge worth naming: `DELETE /api/cli/token` answers **200 with `ok:false`** for an id that is not yours — revocation is scoped to the owner, which is how another person's token stays theirs. Read as success, that would drop the row from the list while the token kept working, so `ok === false` is treated as a failure here.

### login/page.tsx

`safeCallback()` accepts a same-origin relative `callbackUrl` — the form `/cli` sends when it comes back for you, and the only form that survives local development. Absolute URLs are validated with `isPlatformHost()` from `lib/roots.ts` instead of a `supersonic.cv` literal, so the return keeps working after the root moves.

### Verified against a local control plane

Real routes, real rows, signed in through the credentials provider:

| check | result |
|---|---|
| Bearer on `/api/apps`, revoke, Bearer again | `200` → `401` |
| row in `cli_tokens` after revoke | gone |
| another user's token id | `{"ok":false}`, row survives |
| `?port=` handoff to a CLI loopback server | token delivered, authenticates `200` |
| "not you?" round trip | back on `/cli?port=51789…` |
| `tsc --noEmit` | clean |
| `npm test` | 1493/1500 — the 7 failures are in `test/deploy-pipeline.test.ts` and fail identically on a clean checkout of `main`, untouched by this change |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N11h6fXgbnPWE7XoJfvWvU
