### PR TITLE
An app can be shared with a company, not only with a list of people

### DIFF
--- a/apps/web/app/api/apps/[slug]/share/route.ts
+++ b/apps/web/app/api/apps/[slug]/share/route.ts
@@ -1,12 +1,18 @@
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-import { getAppBySlug, setVisibility, listGrants, addGrant, removeGrant, type Visibility } from "@/lib/apps";
+import {
+  getAppBySlug, setVisibility,
+  listGrants, addGrant, removeGrant,
+  listDomainGrants, addDomainGrant, removeDomainGrant, workspaceDomainOfApp,
+  type Visibility,
+} from "@/lib/apps";
 import { listPending, resolveRequest } from "@/lib/requests";
 import { sendAccessGranted } from "@/lib/email";
 import { currentUserId } from "@/lib/session";
 import { entitlement, countPublicApps } from "@/lib/entitlements";
 import { publicLimitMessage, noAccountMessage } from "@/lib/plan-copy";
+import { normalizeDomain, isPublicEmailProvider } from "@/lib/workspace";
 import { corsFor, optionsHandler } from "@/lib/cors";
 
 const VISIBILITIES: Visibility[] = ["private", "shared", "public"];
@@ -25,13 +31,27 @@ async function ownedApp(slug: string) {
   return app;
 }
 
+/**
+ * Everything the panel draws, in one shape, so GET and POST cannot drift.
+ *
+ * `workspaceDomain` is the owner's own company domain (null for a personal
+ * account), and it is here for the one-click suggestion — "everyone at luwo.ai"
+ * is the rule people mean nine times out of ten, and typing it out is the part
+ * they get wrong.
+ */
+async function state(slug: string, visibility: Visibility | undefined) {
+  const [grants, domains, requests, workspaceDomain] = await Promise.all([
+    listGrants(slug), listDomainGrants(slug), listPending(slug), workspaceDomainOfApp(slug),
+  ]);
+  return { visibility, grants, domains, requests, workspaceDomain };
+}
+
 export async function GET(req: Request, { params }: { params: { slug: string } }) {
   const slug = decodeURIComponent(params.slug);
   const cors = corsFor(req, slug);
   const app = await ownedApp(slug);
   if (!app) return Response.json({ error: "forbidden" }, { status: 403, headers: cors });
-  const [grants, requests] = await Promise.all([listGrants(slug), listPending(slug)]);
-  return Response.json({ visibility: app.visibility, grants, requests }, { headers: cors });
+  return Response.json(await state(slug, app.visibility), { headers: cors });
 }
 
 export async function POST(req: Request, { params }: { params: { slug: string } }) {
@@ -101,10 +121,38 @@ export async function POST(req: Request, { params }: { params: { slug: string } 
     await resolveRequest(slug, email, "approved");
     await sendAccessGranted(email, slug);
   }
+  if (body.addDomain) {
+    const domain = normalizeDomain(String(body.addDomain));
+    if (!domain) {
+      return Response.json({ error: "that isn't a domain" }, { status: 400, headers: cors });
+    }
+    // A consumer provider is not an organisation. A rule for gmail.com admits
+    // everybody with a browser, which is `public` — and `public` is the one
+    // visibility that is counted, capped, and says so on the app. Letting it be
+    // spelled as a domain rule would route around all three.
+    if (isPublicEmailProvider(domain)) {
+      return Response.json(
+        { error: `${domain} is everyone's address, not an organisation. Choose Public if you mean anyone.` },
+        { status: 400, headers: cors }
+      );
+    }
+    const ent = await entitlement(app.owner_id);
+    if (ent.locked) {
+      return Response.json({ error: noAccountMessage(), paywall: true, reason: "no_account" }, { status: 402, headers: cors });
+    }
+    // No email is sent: a rule has no recipient. The people it admits find out
+    // by opening the link, which is the whole point of a rule over an invite.
+    await addDomainGrant(slug, domain);
+  }
   if (body.removeEmail) await removeGrant(slug, String(body.removeEmail));
+  // Normalised on the way out too, so removing a rule shown as "@luwo.ai"
+  // deletes the row stored as "luwo.ai".
+  if (body.removeDomain) {
+    const domain = normalizeDomain(String(body.removeDomain));
+    if (domain) await removeDomainGrant(slug, domain);
+  }
   if (body.denyEmail) await resolveRequest(slug, String(body.denyEmail), "denied");
 
   const fresh = await getAppBySlug(slug);
-  const [grants, requests] = await Promise.all([listGrants(slug), listPending(slug)]);
-  return Response.json({ visibility: fresh?.visibility, grants, requests }, { headers: cors });
+  return Response.json(await state(slug, fresh?.visibility), { headers: cors });
 }

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -4,7 +4,7 @@ import Google from "next-auth/providers/google";
 import GitHub from "next-auth/providers/github";
 import bcrypt from "bcryptjs";
 import { authConfig } from "./auth.config";
-import { findUserByEmailAndProvider, createUser } from "@/lib/users";
+import { findUserByEmailAndProvider, createUser, markEmailVerified } from "@/lib/users";
 import { resolveWorkspaceForEmail } from "@/lib/workspace";
 import { getPool } from "@/lib/db";
 
@@ -35,6 +35,19 @@ if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
   providers.push(Google({
     clientId: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    // The default profile drops `email_verified`, and a domain rule needs it:
+    // "anyone at luwo.ai" may only admit somebody Google says holds that
+    // address. Google sets it false for an unverified alias on a consumer
+    // account, so it is read rather than assumed.
+    profile(profile) {
+      return {
+        id: profile.sub,
+        name: profile.name,
+        email: profile.email,
+        image: profile.picture,
+        emailVerified: profile.email_verified === true,
+      };
+    },
   }));
 }
 if (process.env.GITHUB_ID && process.env.GITHUB_SECRET) {
@@ -47,6 +60,9 @@ if (process.env.GITHUB_ID && process.env.GITHUB_SECRET) {
     // (the user:email scope, requested by default, authorizes this).
     async profile(profile, tokens) {
       let email = profile.email as string | null;
+      // GitHub only publishes an address on /user that the account has verified,
+      // so a public one is proof; the /user/emails path below decides for itself.
+      let verified = !!email;
       if (!email) {
         try {
           const res = await fetch("https://api.github.com/user/emails", {
@@ -54,11 +70,16 @@ if (process.env.GITHUB_ID && process.env.GITHUB_SECRET) {
           });
           if (res.ok) {
             const emails = (await res.json()) as { email: string; primary: boolean; verified: boolean }[];
-            email = (emails.find((e) => e.primary && e.verified) ?? emails.find((e) => e.verified) ?? emails[0])?.email ?? null;
+            const proven = emails.find((e) => e.primary && e.verified) ?? emails.find((e) => e.verified);
+            // The unverified fallback still signs the person in — it is their
+            // account either way — but it is NOT evidence of the domain, so it
+            // is remembered as unverified and no domain rule will admit it.
+            email = (proven ?? emails[0])?.email ?? null;
+            verified = !!proven;
           }
         } catch { /* leave email null — signIn will reject with a clear path */ }
       }
-      return { id: profile.id.toString(), name: (profile.name ?? profile.login) as string, email, image: profile.avatar_url as string };
+      return { id: profile.id.toString(), name: (profile.name ?? profile.login) as string, email, image: profile.avatar_url as string, emailVerified: verified };
     },
   }));
 }
@@ -94,6 +115,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
       if (account && account.provider !== "credentials") {
         await createUser(user.email, user.name ?? "", null, account.provider);
+        // Whether the provider PROVED this address, recorded on the row because
+        // the edge reads it long after this request: a domain rule ("anyone at
+        // luwo.ai") may only admit a proven address. Signup with a password
+        // proves nothing, so those rows stay false and are admitted by name
+        // only — which is safe, because there the owner typed the address.
+        //
+        // Only ever raised, never lowered. GitHub can answer "verified" once and
+        // fall back to an unverified address later; the proof already happened.
+        if ((user as { emailVerified?: boolean }).emailVerified) {
+          await markEmailVerified(user.email, account.provider);
+        }
       }
       // Only resolve a workspace for a user who doesn't have one yet.
       // resolveWorkspaceForEmail creates a row for personal addresses, so calling

--- a/apps/web/components/SharePanel.tsx
+++ b/apps/web/components/SharePanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Globe, Lock, Users, X } from "lucide-react";
+import { AtSign, Globe, Lock, Mail, Users, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Row, RowGroup, RowList } from "@/components/panel/atoms";
@@ -15,6 +15,11 @@ import { Row, RowGroup, RowList } from "@/components/panel/atoms";
  * default sitting on nothing: floating options with no container, an uppercase
  * label, and a tinted pink band for the current choice.
  *
+ * "Specific people" holds two kinds of row: a person, and a whole company —
+ * "@luwo.ai" is one rule that stands for everyone there, and it is a row beside
+ * the people rather than a fourth option, so the list answers "who is in?" in
+ * one place.
+ *
  * The three options are one list of rows, which is what a mutually exclusive
  * choice looks like everywhere else here: the current one is filled and ticked,
  * not tinted with the accent. Red means something is wrong; it cannot also mean
@@ -25,15 +30,31 @@ type Visibility = "private" | "shared" | "public";
 
 const OPTIONS: { id: Visibility; icon: typeof Lock; label: string; desc: string }[] = [
   { id: "private", icon: Lock, label: "Only me", desc: "Just you can open it" },
-  { id: "shared", icon: Users, label: "Specific people", desc: "People you invite by email" },
+  { id: "shared", icon: Users, label: "Specific people", desc: "People you invite, or a whole company" },
   { id: "public", icon: Globe, label: "Public", desc: "Anyone with the link" },
 ];
+
+/**
+ * Is what they typed a company, or a person?
+ *
+ * `@luwo.ai` and `luwo.ai` are the company; `boris@luwo.ai` is Boris. One field
+ * for both because that is how people write it — nobody wants to pick a mode
+ * before typing an address. The server normalises and refuses; this only decides
+ * which name the value is sent under.
+ */
+function isDomainInput(value: string): boolean {
+  const v = value.trim();
+  return v.startsWith("@") || !v.includes("@");
+}
 
 export default function SharePanel({ slug }: { slug: string }) {
   const [visibility, setVisibility] = useState<Visibility>("private");
   const [grants, setGrants] = useState<string[]>([]);
+  const [domains, setDomains] = useState<string[]>([]);
   const [requests, setRequests] = useState<string[]>([]);
-  const [email, setEmail] = useState("");
+  const [workspaceDomain, setWorkspaceDomain] = useState<string | null>(null);
+  /** One field for both an address and a company — see `isDomainInput`. */
+  const [who, setWho] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -47,7 +68,9 @@ export default function SharePanel({ slug }: { slug: string }) {
       const j = await r.json();
       setVisibility(j.visibility);
       setGrants(j.grants ?? []);
+      setDomains(j.domains ?? []);
       setRequests(j.requests ?? []);
+      setWorkspaceDomain(j.workspaceDomain ?? null);
     } catch {
       setError("Couldn't load sharing settings");
     }
@@ -72,7 +95,9 @@ export default function SharePanel({ slug }: { slug: string }) {
       }
       setVisibility(j.visibility);
       setGrants(j.grants ?? []);
+      setDomains(j.domains ?? []);
       setRequests(j.requests ?? []);
+      setWorkspaceDomain(j.workspaceDomain ?? null);
     } catch {
       setError("Couldn't reach the server");
     } finally {
@@ -117,47 +142,101 @@ export default function SharePanel({ slug }: { slug: string }) {
       </RowList>
 
       {visibility === "shared" && (
-        <RowGroup title="People">
-          {grants.map((g) => (
-            <Row key={g} title={<span className="font-mono text-[13px]">{g}</span>}>
-              <Button
-                aria-label={`Remove ${g}`}
-                className="size-7 text-ink-3 hover:text-ink"
-                disabled={busy}
-                onClick={() => post({ removeEmail: g })}
-                size="icon-sm"
-                variant="ghost"
+        <div className="flex flex-col gap-2.5">
+          <RowGroup title="People and companies">
+            {/* Rules first: one row here can stand for a hundred below it, so
+                reading them in the other order tells you who is in too late. */}
+            {domains.map((d) => (
+              <Row
+                icon={Globe}
+                key={d}
+                sub="Anyone signed in with a verified address there"
+                title={<span className="font-mono text-[13px]">@{d}</span>}
               >
-                <X className="size-3.5" />
-              </Button>
-            </Row>
-          ))}
+                <Button
+                  aria-label={`Remove @${d}`}
+                  className="size-7 text-ink-3 hover:text-ink"
+                  disabled={busy}
+                  onClick={() => post({ removeDomain: d })}
+                  size="icon-sm"
+                  variant="ghost"
+                >
+                  <X className="size-3.5" />
+                </Button>
+              </Row>
+            ))}
 
-          {/* The form is the last row of the list, not a control floating under
-              it — an invite belongs with the people it joins. */}
-          <form
-            className="flex items-center gap-2 px-4 py-3"
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (email) {
-                post({ addEmail: email });
-                setEmail("");
-              }
-            }}
-          >
-            <Input
-              className="h-9"
-              onChange={(e) => setEmail(e.currentTarget.value)}
-              placeholder="colleague@company.com"
-              type="email"
-              value={email}
-            />
-            <Button disabled={busy || !email} type="submit">
-              Add
-            </Button>
-          </form>
-        </RowGroup>
+            {grants.map((g) => (
+              <Row icon={Mail} key={g} title={<span className="font-mono text-[13px]">{g}</span>}>
+                <Button
+                  aria-label={`Remove ${g}`}
+                  className="size-7 text-ink-3 hover:text-ink"
+                  disabled={busy}
+                  onClick={() => post({ removeEmail: g })}
+                  size="icon-sm"
+                  variant="ghost"
+                >
+                  <X className="size-3.5" />
+                </Button>
+              </Row>
+            ))}
+
+            {/* The form is the last row of the list, not a control floating under
+                it — an invite belongs with the people it joins. */}
+            <form
+              className="flex items-center gap-2 px-4 py-3"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const v = who.trim();
+                if (!v) return;
+                post(isDomainInput(v) ? { addDomain: v } : { addEmail: v });
+                setWho("");
+              }}
+            >
+              {/* Not type="email": the browser refuses "@luwo.ai" on its own,
+                  and the whole point of one field is that both spellings land. */}
+              <Input
+                className="h-9"
+                inputMode="email"
+                onChange={(e) => setWho(e.currentTarget.value)}
+                placeholder="colleague@company.com or @company.com"
+                type="text"
+                value={who}
+              />
+              <Button disabled={busy || !who.trim()} type="submit">
+                Add
+              </Button>
+            </form>
+          </RowGroup>
+
+          {/* The rule people actually mean, one click, spelled correctly. Only
+              for a company account — a personal workspace has no domain, and
+              "everyone at gmail.com" is not an organisation. */}
+          {workspaceDomain && !domains.includes(workspaceDomain) && (
+            <div>
+              <Button
+                className="gap-1.5"
+                disabled={busy}
+                onClick={() => post({ addDomain: workspaceDomain })}
+                size="sm"
+                variant="outline"
+              >
+                <AtSign className="size-3.5" />
+                Everyone at {workspaceDomain}
+              </Button>
+            </div>
+          )}
+
+          {domains.length > 0 && (
+            <p className="px-0.5 text-[13px] text-ink-3">
+              A company rule admits people who signed in with Google or GitHub on that address.
+              Someone who signed up with a password is asked to sign in that way first — we can&apos;t
+              tell the address is theirs otherwise.
+            </p>
+          )}
+        </div>
       )}
+
     </div>
   );
 }

--- a/apps/web/db/034_domain_grants.sql
+++ b/apps/web/db/034_domain_grants.sql
@@ -1,0 +1,30 @@
+-- Access by ORGANISATION: "anyone with an @luwo.ai address", as a rule on the
+-- app rather than a row per person.
+--
+-- A rule is not a person, so it is not a row in app_grants: that table's key is
+-- an address, every reader of it treats a value as somebody who was invited by
+-- name, and `email = 'luwo.ai'` would have been a lie in both directions.
+CREATE TABLE IF NOT EXISTS app_domain_grants (
+  app_id     uuid NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  domain     text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (app_id, domain)
+);
+
+-- Whether the identity provider proved this address belongs to this person.
+--
+-- Signup with a password asks for an address and never checks it, so a domain
+-- rule read off an unverified row would mean "anyone who TYPED @luwo.ai" —
+-- which is not a boundary at all, it is `public` with extra steps. Only a
+-- verified row may satisfy a domain rule; invitations by name are unaffected,
+-- because there the owner named the address themselves.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified boolean NOT NULL DEFAULT false;
+
+-- Google is backfilled: the address comes from the Workspace/Gmail account the
+-- person just signed into, and we only ever accepted it with email_verified set.
+--
+-- GitHub is NOT backfilled, on purpose. Until this change the profile fallback
+-- would take an UNVERIFIED address off /user/emails when nothing verified was
+-- there, so an existing github row is not evidence of anything. Those rows flip
+-- to true on the owner's next sign-in, through the verified path in auth.ts.
+UPDATE users SET email_verified = true WHERE provider = 'google' AND email_verified = false;

--- a/apps/web/lib/apps.ts
+++ b/apps/web/lib/apps.ts
@@ -350,3 +350,42 @@ export async function removeGrant(slug: string, email: string): Promise<void> {
     [slug, email.trim().toLowerCase()]
   );
 }
+
+// Domain rules — "anyone with an @luwo.ai address". Stored per app, beside the
+// people invited by name, and read by the edge with SQL equality (see
+// `normalizeDomain` in lib/workspace.ts for why equality and not a suffix).
+
+export async function listDomainGrants(slug: string): Promise<string[]> {
+  const r = await getPool(DB).query(
+    `SELECT g.domain FROM app_domain_grants g JOIN apps a ON a.id = g.app_id
+     WHERE a.slug = $1 ORDER BY g.domain`,
+    [slug]
+  );
+  return r.rows.map((x: { domain: string }) => x.domain);
+}
+
+export async function addDomainGrant(slug: string, domain: string): Promise<void> {
+  await getPool(DB).query(
+    `INSERT INTO app_domain_grants(app_id, domain)
+     SELECT a.id, $2 FROM apps a WHERE a.slug = $1
+     ON CONFLICT DO NOTHING`,
+    [slug, domain]
+  );
+}
+
+export async function removeDomainGrant(slug: string, domain: string): Promise<void> {
+  await getPool(DB).query(
+    `DELETE FROM app_domain_grants g USING apps a
+     WHERE g.app_id = a.id AND a.slug = $1 AND g.domain = $2`,
+    [slug, domain]
+  );
+}
+
+/** The domain of the workspace this app belongs to, or null for a personal one. */
+export async function workspaceDomainOfApp(slug: string): Promise<string | null> {
+  const r = await getPool(DB).query(
+    `SELECT w.domain FROM apps a JOIN workspaces w ON w.id = a.workspace_id WHERE a.slug = $1`,
+    [slug]
+  );
+  return r.rows[0]?.domain ?? null;
+}

--- a/apps/web/lib/chat/tools.ts
+++ b/apps/web/lib/chat/tools.ts
@@ -2,7 +2,7 @@ import { getTenantPool, dbNameForSlug } from "@/lib/db";
 import { appLogs } from "@/lib/app-logs";
 import { describeService, getErrors } from "@/lib/gcloud";
 import { getDeploy } from "@/lib/deploys";
-import { getAppBySlug, listGrants } from "@/lib/apps";
+import { getAppBySlug, listGrants, listDomainGrants } from "@/lib/apps";
 import { listPending } from "@/lib/requests";
 import { envKeysFor } from "@/lib/env-keys";
 import { websiteStats } from "@/lib/umami";
@@ -186,8 +186,13 @@ export function toolsFor(slug: string, cookie?: string): Handler {
 
         case "access": {
           const app = await getAppBySlug(slug);
-          const [grants, requests] = await Promise.all([listGrants(slug), listPending(slug)]);
-          return { ok: true, data: { visibility: app?.visibility ?? "private", grants, requests } };
+          const [grants, domains, requests] = await Promise.all([
+            listGrants(slug), listDomainGrants(slug), listPending(slug),
+          ]);
+          // `domains` is people too — a rule for "luwo.ai" admits everyone there
+          // with a verified address, so an answer that listed only `grants`
+          // would under-report who can open the app.
+          return { ok: true, data: { visibility: app?.visibility ?? "private", grants, domains, requests } };
         }
 
         case "live": {

--- a/apps/web/lib/users.ts
+++ b/apps/web/lib/users.ts
@@ -58,3 +58,18 @@ export async function createUser(email: string, name: string, passwordHash: stri
   );
   return r.rows[0];
 }
+
+/**
+ * Record that the identity provider proved this address belongs to this person.
+ *
+ * Raised only — see the note at the call site in auth.ts. A password account
+ * never reaches here, which is the point: `users.email_verified` is what a
+ * domain rule on an app is allowed to trust.
+ */
+export async function markEmailVerified(email: string, provider: string): Promise<void> {
+  await getPool(DB).query(
+    `UPDATE users SET email_verified = true
+     WHERE email = $1 AND provider = $2 AND email_verified = false`,
+    [email.toLowerCase(), provider]
+  );
+}

--- a/apps/web/lib/workspace.ts
+++ b/apps/web/lib/workspace.ts
@@ -66,3 +66,33 @@ export async function resolveWorkspaceForEmail(email: string, executor?: Queryab
   );
   return r.rows[0].id;
 }
+
+/**
+ * A domain typed by a person, as the value a rule is stored under — or "" when
+ * it is not a domain at all.
+ *
+ * Accepts the three spellings people actually type for the same thing:
+ * `@luwo.ai`, `luwo.ai`, and a whole address `boris@luwo.ai`. Everything else
+ * is refused rather than repaired, because a rule that silently became a
+ * different domain than the one on screen is a rule nobody can audit.
+ *
+ * The value is what the edge compares a visitor's domain to, with SQL equality.
+ * That equality is the point: matching with a suffix test would make a rule for
+ * `luwo.ai` also admit `evil-luwo.ai`, which anyone can register — the same
+ * mistake `lib/allowlist.ts` carries a comment about.
+ */
+export function normalizeDomain(input: string): string {
+  const raw = input.trim().toLowerCase();
+  if (!raw) return "";
+  // A whole address is the commonest paste; take the domain half through the
+  // same parser that refuses `boris@luwo.ai@evil.com`.
+  if (raw.includes("@")) return domainOf(raw.startsWith("@") ? `x${raw}` : raw);
+  // 253 is the maximum length of a hostname; a label is 1-63 of [a-z0-9-] and
+  // may not start or end with a hyphen. No wildcards: "*" is how the sign-in
+  // allowlist spells "everyone", and an app that means everyone is `public`.
+  if (raw.length > 253) return "";
+  const labels = raw.split(".");
+  if (labels.length < 2) return "";
+  const label = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+  return labels.every((l) => label.test(l)) ? raw : "";
+}

--- a/apps/web/test/workspace.test.ts
+++ b/apps/web/test/workspace.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isPublicEmailProvider, domainOf } from "../lib/workspace";
+import { isPublicEmailProvider, domainOf, normalizeDomain } from "../lib/workspace";
 
 test("domainOf lowercases and takes the part after @", () => {
   assert.equal(domainOf("Boris@Acme.COM"), "acme.com");
@@ -32,4 +32,35 @@ test("domainOf refuses anything that is not exactly local@domain", () => {
   assert.equal(domainOf("boris@luwo.ai."), "");
   assert.equal(domainOf("boris@localhost"), "");
   assert.equal(domainOf("Boris@Luwo.AI"), "luwo.ai");
+});
+
+// normalizeDomain — the value an app's "anyone at luwo.ai" rule is stored under.
+
+test("normalizeDomain accepts the three spellings people type", () => {
+  for (const typed of ["luwo.ai", "@luwo.ai", "boris@luwo.ai", "  @LUWO.ai  "]) {
+    assert.equal(normalizeDomain(typed), "luwo.ai", `${JSON.stringify(typed)} is luwo.ai`);
+  }
+});
+
+// The address routes to evil.com, so it must not become a rule for luwo.ai.
+test("normalizeDomain refuses an address with two @", () => {
+  assert.equal(normalizeDomain("boris@luwo.ai@evil.com"), "");
+});
+
+test("normalizeDomain refuses what is not a domain", () => {
+  for (const bad of ["", "   ", "luwo", "luwo.", ".ai", "lu wo.ai", "luwo..ai", "-luwo.ai", "luwo-.ai", "https://luwo.ai", "luwo.ai/apps"]) {
+    assert.equal(normalizeDomain(bad), "", `${JSON.stringify(bad)} is not a domain`);
+  }
+});
+
+// "*" is how the sign-in allowlist spells "everyone". An app that means everyone
+// is `public` — which is counted and capped — so it must not be spellable here.
+test("normalizeDomain refuses a wildcard", () => {
+  for (const bad of ["*", "*.luwo.ai", "@*"]) {
+    assert.equal(normalizeDomain(bad), "", `${JSON.stringify(bad)} is not a domain`);
+  }
+});
+
+test("normalizeDomain refuses a hostname longer than 253 characters", () => {
+  assert.equal(normalizeDomain(`${"a".repeat(250)}.com`), "");
 });

--- a/services/proxy/src/access.test.ts
+++ b/services/proxy/src/access.test.ts
@@ -1,6 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { decideAccess } from "./access";
+import { decideAccess, domainOf, type AccessInput } from "./access";
+
+/**
+ * decideAccess with the two domain-rule answers defaulted to "no rule, nothing
+ * proven", so every test that is not about domains reads as it did before them.
+ */
+function allows(i: Omit<AccessInput, "domainRuleMatches" | "visitorEmailVerified"> &
+  Partial<Pick<AccessInput, "domainRuleMatches" | "visitorEmailVerified">>): boolean {
+  return decideAccess({ domainRuleMatches: false, visitorEmailVerified: false, ...i });
+}
 
 const app = {
   id: "app-1",
@@ -13,50 +22,50 @@ const colleague = { userId: "user-boris", email: "boris@acme.com" };
 const outsider = { userId: "user-eve", email: "eve@other.com" };
 
 test("owner can always open their own private app", () => {
-  assert.equal(decideAccess({ app, visitor: owner, visitorWorkspaceId: "ws-acme", hasGrant: false }), true);
+  assert.equal(allows({ app, visitor: owner, visitorWorkspaceId: "ws-acme", hasGrant: false }), true);
 });
 
 test("colleague cannot open a private app", () => {
-  assert.equal(decideAccess({ app, visitor: colleague, visitorWorkspaceId: "ws-acme", hasGrant: false }), false);
+  assert.equal(allows({ app, visitor: colleague, visitorWorkspaceId: "ws-acme", hasGrant: false }), false);
 });
 
 test("colleague in the same workspace can open a workspace app", () => {
-  assert.equal(decideAccess({
+  assert.equal(allows({
     app: { ...app, visibility: "workspace" }, visitor: colleague,
     visitorWorkspaceId: "ws-acme", hasGrant: false,
   }), true);
 });
 
 test("outsider cannot open a workspace app", () => {
-  assert.equal(decideAccess({
+  assert.equal(allows({
     app: { ...app, visibility: "workspace" }, visitor: outsider,
     visitorWorkspaceId: "ws-other", hasGrant: false,
   }), false);
 });
 
 test("granted email can open a shared app", () => {
-  assert.equal(decideAccess({
+  assert.equal(allows({
     app: { ...app, visibility: "shared" }, visitor: outsider,
     visitorWorkspaceId: "ws-other", hasGrant: true,
   }), true);
 });
 
 test("ungranted email cannot open a shared app", () => {
-  assert.equal(decideAccess({
+  assert.equal(allows({
     app: { ...app, visibility: "shared" }, visitor: outsider,
     visitorWorkspaceId: "ws-other", hasGrant: false,
   }), false);
 });
 
 test("a null visitor workspace never matches a workspace app", () => {
-  assert.equal(decideAccess({
+  assert.equal(allows({
     app: { ...app, visibility: "workspace" }, visitor: colleague,
     visitorWorkspaceId: null, hasGrant: false,
   }), false);
 });
 
 test("workspace visibility does not imply grant access for a different workspace", () => {
-  assert.equal(decideAccess({
+  assert.equal(allows({
     app: { ...app, visibility: "workspace" }, visitor: outsider,
     visitorWorkspaceId: null, hasGrant: true,
   }), false);
@@ -67,7 +76,7 @@ test("workspace visibility does not imply grant access for a different workspace
 // typo or a new enum value into an open door.
 test("an unrecognized visibility denies everyone", () => {
   for (const visibility of ["", "deleted", "PRIVATE"]) {
-    assert.equal(decideAccess({
+    assert.equal(allows({
       app: { ...app, visibility: visibility as never }, visitor: colleague,
       visitorWorkspaceId: "ws-acme", hasGrant: true,
     }), false, `visibility ${JSON.stringify(visibility)} should deny`);
@@ -76,7 +85,7 @@ test("an unrecognized visibility denies everyone", () => {
 
 test("public visibility lets anyone in", () => {
   for (const visitor of [colleague, outsider]) {
-    assert.equal(decideAccess({
+    assert.equal(allows({
       app: { ...app, visibility: "public" }, visitor,
       visitorWorkspaceId: null, hasGrant: false,
     }), true);
@@ -87,9 +96,75 @@ test("public visibility lets anyone in", () => {
 // two so a refactor cannot reorder it away unnoticed.
 test("the owner can open their app at every visibility", () => {
   for (const visibility of ["private", "shared", "workspace"] as const) {
-    assert.equal(decideAccess({
+    assert.equal(allows({
       app: { ...app, visibility }, visitor: owner,
       visitorWorkspaceId: null, hasGrant: false,
     }), true, `owner should open a ${visibility} app`);
+  }
+});
+
+// Access by ORGANISATION: the app admits a domain rather than a list of people.
+
+test("a verified address at a granted domain opens a shared app", () => {
+  assert.equal(allows({
+    app: { ...app, visibility: "shared" }, visitor: colleague,
+    visitorWorkspaceId: "ws-acme", hasGrant: false,
+    domainRuleMatches: true, visitorEmailVerified: true,
+  }), true);
+});
+
+// The failure this pins: signup with a password asks for an address and never
+// checks it. If an unproven address satisfied a domain rule, anyone could type
+// boris@acme.com into our own signup form and walk into every app acme shares
+// with its own staff — the rule would be `public` wearing a domain.
+test("an unverified address at a granted domain is refused", () => {
+  assert.equal(allows({
+    app: { ...app, visibility: "shared" }, visitor: colleague,
+    visitorWorkspaceId: "ws-acme", hasGrant: false,
+    domainRuleMatches: true, visitorEmailVerified: false,
+  }), false);
+});
+
+// Being invited BY NAME is unaffected by verification: the owner typed that
+// address themselves, so there is nothing for us to prove about it.
+test("a named invitation still opens the app without a verified address", () => {
+  assert.equal(allows({
+    app: { ...app, visibility: "shared" }, visitor: outsider,
+    visitorWorkspaceId: null, hasGrant: true,
+    domainRuleMatches: false, visitorEmailVerified: false,
+  }), true);
+});
+
+test("a verified address with no matching rule is still refused", () => {
+  assert.equal(allows({
+    app: { ...app, visibility: "shared" }, visitor: outsider,
+    visitorWorkspaceId: null, hasGrant: false,
+    domainRuleMatches: false, visitorEmailVerified: true,
+  }), false);
+});
+
+// A domain rule belongs to `shared` alone. On a private app it must be inert,
+// or archiving an app by setting it private would leave a door open.
+test("a domain rule does not open a private app", () => {
+  assert.equal(allows({
+    app: { ...app, visibility: "private" }, visitor: colleague,
+    visitorWorkspaceId: "ws-acme", hasGrant: false,
+    domainRuleMatches: true, visitorEmailVerified: true,
+  }), false);
+});
+
+test("domainOf takes the domain half, lowercased", () => {
+  assert.equal(domainOf("Boris@Acme.COM"), "acme.com");
+});
+
+// The one that matters: mail for this address routes to evil.com, and reading
+// the last field would hand it a rule written for luwo.ai.
+test("domainOf refuses an address with two @", () => {
+  assert.equal(domainOf("boris@luwo.ai@evil.com"), "");
+});
+
+test("domainOf refuses what is not a deliverable domain", () => {
+  for (const bad of ["", "boris", "boris@", "@acme.com", "boris@acme", "boris@.com", "boris@acme."]) {
+    assert.equal(domainOf(bad), "", `${JSON.stringify(bad)} is not a domain`);
   }
 });

--- a/services/proxy/src/access.ts
+++ b/services/proxy/src/access.ts
@@ -10,6 +10,23 @@ export interface AccessInput {
   visitor: { userId: string; email: string };
   visitorWorkspaceId: string | null;
   hasGrant: boolean;
+  /**
+   * The app carries a rule for the domain this visitor's address is on —
+   * "anyone at luwo.ai". Resolved by the caller with SQL equality, never a
+   * suffix test: a rule for luwo.ai must not admit evil-luwo.ai, which anyone
+   * can register.
+   */
+  domainRuleMatches: boolean;
+  /**
+   * The identity provider PROVED this address belongs to this visitor.
+   *
+   * Signing up with a password asks for an address and never checks it, so
+   * without this a rule for luwo.ai would admit anyone who typed a luwo.ai
+   * address into our own signup form — the rule would be public with extra
+   * steps. Being invited by name is unaffected: there the owner named the
+   * address, so nothing has to be proven to us.
+   */
+  visitorEmailVerified: boolean;
 }
 
 /**
@@ -29,10 +46,28 @@ export function decideAccess(i: AccessInput): boolean {
     case "workspace":
       return i.visitorWorkspaceId !== null && i.visitorWorkspaceId === i.app.workspace_id;
     case "shared":
-      return i.hasGrant;
+      return i.hasGrant || (i.domainRuleMatches && i.visitorEmailVerified);
     case "private":
       return false;
     default:
       return false;
   }
+}
+
+/**
+ * The domain an address delivers to, or "" if it is not one address.
+ *
+ * A copy of `domainOf` in the control plane's lib/workspace.ts, and it must stay
+ * one: reading the LAST field instead would make `boris@luwo.ai@evil.com` look
+ * like luwo.ai while mail routes to evil.com — enough to satisfy a domain rule
+ * for a company the visitor has nothing to do with. Anything that is not exactly
+ * local@domain is refused, and every caller reads "" as "no domain".
+ */
+export function domainOf(email: string): string {
+  const parts = email.trim().toLowerCase().split("@");
+  if (parts.length !== 2) return "";
+  const [local, domain] = parts;
+  if (!local || !domain) return "";
+  if (!domain.includes(".") || domain.startsWith(".") || domain.endsWith(".")) return "";
+  return domain;
 }

--- a/services/proxy/src/index.ts
+++ b/services/proxy/src/index.ts
@@ -1,13 +1,13 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { config } from "./config";
-import { lookupApp, lookupAppByHost, hasGrant, workspaceOfUser, workspaceDomainOf, registryStaleFor } from "./registry";
-import { page403, page404, pageGate, pageFailed, pageStalled, pageNoWeb } from "./pages";
+import { lookupApp, lookupAppByHost, hasGrant, hasDomainGrant, emailIsVerified, workspaceOfUser, workspaceDomainOf, registryStaleFor } from "./registry";
+import { page403, page404, pageGate, pageProve, pageFailed, pageStalled, pageNoWeb } from "./pages";
 import { pageRoom } from "./room-page";
 import { serveRoomEvents } from "./room";
 import { assembleReading, liveDeps } from "./reading";
 import { wantsHtml } from "./negotiate";
 import { viewerOnce, authUrls, hasCredential } from "./session";
-import { decideAccess } from "./access";
+import { decideAccess, domainOf } from "./access";
 import { decideEdge } from "./edge";
 import { doorFor, mustReturnToPlatform, platformUrl } from "./door";
 import { pickRoute, pickPrefix } from "./routes";
@@ -308,12 +308,25 @@ async function handle(req: IncomingMessage, res: ServerResponse) {
     return html(res, 401, pageGate(loginUrl, signupUrl));
   }
 
-  const [visitorWorkspaceId, granted] = await Promise.all([
+  // A domain rule is only asked about for a `shared` app, and only then is the
+  // visitor's own verification read — an app with no rules pays for neither.
+  const visitorDomain = app.visibility === "shared" ? domainOf(visitor.email) : "";
+  const [visitorWorkspaceId, granted, domainRuleMatches, visitorEmailVerified] = await Promise.all([
     workspaceOfUser(visitor.userId),
     app.visibility === "shared" ? hasGrant(app.id, visitor.email) : Promise.resolve(false),
+    visitorDomain ? hasDomainGrant(app.id, visitorDomain) : Promise.resolve(false),
+    visitorDomain ? emailIsVerified(visitor.userId) : Promise.resolve(false),
   ]);
 
-  if (!decideAccess({ app, visitor, visitorWorkspaceId, hasGrant: granted })) {
+  if (!decideAccess({ app, visitor, visitorWorkspaceId, hasGrant: granted, domainRuleMatches, visitorEmailVerified })) {
+    // One case is not a refusal so much as an unfinished proof: this app admits
+    // everyone at their domain, and they are signed in with a password account,
+    // which proves nothing about the address. Saying "request access" there
+    // sends them to bother the owner for something they already have — so they
+    // are told the one move that opens it.
+    if (domainRuleMatches && !visitorEmailVerified) {
+      return html(res, 403, pageProve(visitorDomain, authUrls(req).loginUrl));
+    }
     return html(res, 403, page403(slug, "https://app.supersonic.cv"));
   }
 

--- a/services/proxy/src/pages.ts
+++ b/services/proxy/src/pages.ts
@@ -40,6 +40,26 @@ b.onclick=function(){
 <div class="note" id="n"></div></div>`, script);
 }
 
+/**
+ * Shown to a visitor whose DOMAIN is admitted but whose address is not proven.
+ *
+ * They are signed in with a password account, which says nothing about who owns
+ * the address, so the rule cannot admit them. This is the one 403 that is not
+ * "ask the owner": the owner already said yes to everyone at this domain, and
+ * the missing half is a sign-in that proves it. Sending them to request access
+ * instead would have them wait on a person who has nothing left to decide.
+ *
+ * The domain is echoed because it is what makes the sentence make sense, and it
+ * is escaped because it reaches here from a database row.
+ */
+export function pageProve(domain: string, loginUrl: string): string {
+  return shell("Sign in to prove your address", `${MARK}<h1>Almost — prove your address</h1>
+<p>This app is open to everyone at <code>${escapeHtml(domain)}</code>. Your account signed up with a
+password, so we can&#39;t tell that the address is yours. Sign in with Google or GitHub on that
+address and you&#39;re in.</p>
+<div class="btns"><a class="btn" href="${escapeHtml(loginUrl)}">Sign in</a></div>`);
+}
+
 /** Shown to an anonymous visitor on a private app — a soft landing instead of an
  * abrupt redirect to login. Both links carry callbackUrl so they return here. */
 export function pageGate(loginUrl: string, signupUrl: string): string {

--- a/services/proxy/src/registry.ts
+++ b/services/proxy/src/registry.ts
@@ -347,6 +347,34 @@ export async function workspaceOfUser(userId: string): Promise<string | null> {
   return r.rows[0]?.workspace_id ?? null;
 }
 
+/**
+ * Did the identity provider prove this visitor's address?
+ *
+ * A missing row reads false, which is the safe direction: the only thing this
+ * gates is a DOMAIN rule, and a visitor we cannot find is not somebody we can
+ * say holds an address at luwo.ai.
+ */
+export async function emailIsVerified(userId: string): Promise<boolean> {
+  const r = await db().query(`SELECT email_verified FROM users WHERE id = $1`, [userId]);
+  return r.rows[0]?.email_verified === true;
+}
+
+/**
+ * Does this app carry a rule for this domain?
+ *
+ * Equality, in SQL, on a domain the caller took from the address with one split
+ * — never `LIKE` and never a suffix test, or a rule for luwo.ai would also admit
+ * evil-luwo.ai. Same reasoning as the sign-in allowlist in the control plane.
+ */
+export async function hasDomainGrant(appId: string, domain: string): Promise<boolean> {
+  if (!domain) return false;
+  const r = await db().query(
+    `SELECT 1 FROM app_domain_grants WHERE app_id = $1 AND domain = $2`,
+    [appId, domain.toLowerCase()]
+  );
+  return r.rowCount ? r.rowCount > 0 : false;
+}
+
 /** Domain of a workspace, or null if the workspace does not exist. */
 export async function workspaceDomainOf(workspaceId: string): Promise<string | null> {
   const r = await db().query(`SELECT domain FROM workspaces WHERE id = $1`, [workspaceId]);


### PR DESCRIPTION
"Everyone at luwo.ai" was a thing you could only spell one person at a time. This adds the rule — and the verification that makes it a boundary rather than `public` in a domain-shaped hat.

## What changed

- **`app_domain_grants(app_id, domain)`** (migration `034`) — a rule is not a person, so it is not a row in `app_grants`. Read on `shared` exactly where the named grants are.
- **`users.email_verified`** (same migration) — set from Google's `email_verified`, and from GitHub only for an address GitHub says is verified. Raised only, never lowered. Google rows are backfilled; **github rows deliberately are not** (the old profile fallback would take an unverified address, so an existing row is not evidence), and flip on the owner's next sign-in.
- **Proxy** — `decideAccess` on `shared` is now `hasGrant || (domainRuleMatches && visitorEmailVerified)`. A visitor whose domain matches but whose address is unproven gets a 403 that says *sign in with Google*, not one that says *ask the owner*: the owner already said yes to everyone at that domain.
- **API** — `/api/apps/[slug]/share` takes `addDomain` / `removeDomain`; GET and POST both answer `{ visibility, grants, domains, workspaceDomain, requests }`.
- **Panel** — rules listed above people, one field for both spellings (`boris@luwo.ai` is Boris, `@luwo.ai` is the company), and a one-click "Everyone at luwo.ai" from the owner's workspace domain. Built on the row vocabulary from `cfe9292`.
- **Chat `access` tool** returns `domains` too, or it would under-report who can open the app.

`workspace` visibility is left in the schema untouched — this does not resurrect it.

## The two ways a domain rule goes wrong, both closed

- A **suffix test** would make a rule for `luwo.ai` admit `evil-luwo.ai`, which anyone can register. Matching is SQL equality on a domain taken with one split, and `domainOf` refuses `boris@luwo.ai@evil.com`, whose mail routes to evil.com.
- **`gmail.com` is not an organisation.** A rule for a consumer provider admits everybody with a browser — which is `public`, the visibility that is counted, capped and labelled. `normalizeDomain` + `isPublicEmailProvider` refuse it and name the control the owner actually wants.

## Verification

- proxy: 183/183 (`decideAccess` gains six cases, `domainOf` four)
- web: `normalizeDomain` unit tests; suite otherwise unchanged — the 7 failures in `test/deploy-pipeline.test.ts` are pre-existing and reproduce on a clean tree
- `tsc --noEmit` clean in both packages; Next verification build passes

**Not verified against a live database: the migration has not been applied anywhere.**

## Deploy order

`034` must be applied **before** the proxy and control plane ship, or the edge queries a table that does not exist. Migrations here are run by hand.

## Note

`packages/cli`'s `supersonic share <app> add @acme.com` was built in parallel in another session against exactly this wire (`addDomain`/`removeDomain`, `domains`, `workspaceDomain`) and should work against this as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeWEfEHZ1vyy2yZFrSFAUx