### PR TITLE
curl thebay.cloud, and everything the dashboard could do

### DIFF
--- a/apps/landing/lib/wants-markdown.ts
+++ b/apps/landing/lib/wants-markdown.ts
@@ -1,0 +1,49 @@
+/**
+ * Whether this request came from something that reads text, not something that
+ * paints a page.
+ *
+ * The landing page at the root is written for a person: a picture, a headline,
+ * a globe. The same address typed into a terminal — `curl thebay.cloud` — is
+ * almost never a person and never a browser; it is an agent, or the human
+ * driving one, asking the shortest possible question: what is this and how do I
+ * use it. Thirty-eight kilobytes of markup answers that badly. The manual we
+ * already keep at `/llms.txt` answers it exactly, so the root serves that
+ * instead when the client is one of these.
+ *
+ * The rule is deliberately conservative, because the cost of the two mistakes
+ * is not symmetric. Serving markdown to a browser breaks the marketing site;
+ * serving HTML to a curl leaves someone one path away from what they wanted.
+ * So: a client that says it accepts HTML gets HTML, always — that covers every
+ * browser, and it covers the link-preview crawlers (Slack, Twitter, Facebook,
+ * iMessage), which send a wildcard Accept but exist to read the og: tags in
+ * the head of the document.
+ * Only an explicit ask for markdown, an explicit ask for plain text, or a
+ * user-agent that is unmistakably a command-line HTTP client gets the manual.
+ */
+
+/**
+ * Command-line HTTP clients and the libraries an agent shells out through.
+ * Word-bounded so `curlie` matches and `mycurl-browser` does not, and kept to
+ * names that no browser ever sends. `node` is on it because that is the exact
+ * user-agent Node's own `fetch` sends, which is what most agent tooling is —
+ * and it can only be reached by a client that did not ask for HTML.
+ */
+const TERMINAL_CLIENT =
+  /\b(curl|libcurl|wget|httpie|xh|python-requests|urllib|httpx|aiohttp|node|nodejs|node-fetch|undici|axios|bun|deno|go-http-client|okhttp|powershell|lwp::simple|http_request2)\b/i;
+
+export function wantsMarkdown(accept: string | null, userAgent: string | null): boolean {
+  const a = (accept ?? "").toLowerCase();
+
+  // An explicit ask wins over everything, including a browser's own defaults —
+  // `curl -H 'Accept: text/markdown'` is a request, not a hint.
+  if (a.includes("text/markdown") || a.includes("text/x-markdown")) return true;
+
+  // Anything that will render HTML gets HTML. This is the branch that protects
+  // the marketing site, and it is checked before the user-agent so that a
+  // headless browser driving a screenshot still sees the page it is there for.
+  if (a.includes("text/html")) return false;
+
+  if (a.startsWith("text/plain")) return true;
+
+  return TERMINAL_CLIENT.test(userAgent ?? "");
+}

--- a/apps/landing/middleware.ts
+++ b/apps/landing/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { wantsMarkdown } from "./lib/wants-markdown";
+
+/**
+ * One address, two audiences.
+ *
+ * `https://thebay.cloud/` in a browser is the landing page. The same URL in a
+ * terminal — `curl thebay.cloud` — is a coding agent, or the person driving
+ * one, asking what this is and how to use it from the command line. They get
+ * `/llms.txt`: the manual, in markdown, on stdout, at the address they already
+ * guessed. No second URL to learn and no HTML to strip.
+ *
+ * A rewrite and not a redirect: `curl` does not follow redirects unless told
+ * to, so a 307 here would print a Location header and nothing else — which is
+ * precisely the failure this exists to remove. The body arrives on the first
+ * request, at status 200.
+ *
+ * `Vary` is not decoration. The response for `/` now depends on two request
+ * headers, and any cache between here and the reader that does not know that
+ * will eventually hand a browser the manual, or a terminal the markup.
+ */
+export function middleware(req: NextRequest) {
+  if (!wantsMarkdown(req.headers.get("accept"), req.headers.get("user-agent"))) {
+    return NextResponse.next();
+  }
+  const res = NextResponse.rewrite(new URL("/llms.txt", req.url));
+  res.headers.set("Vary", "Accept, User-Agent");
+  res.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+  return res;
+}
+
+/**
+ * The root only. Every other path on this site is already unambiguous, and the
+ * manual keeps its own permanent address at /llms.txt for anyone who asks for
+ * it by name.
+ */
+export const config = { matcher: "/" };

--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+
+  /**
+   * The manual has one file and several names, because the names are guesses.
+   * An agent told "read the docs at thebay.cloud" will try /llms.txt if it
+   * knows that convention and /AGENTS.md or /cli.md if it doesn't, and a guess
+   * that 404s costs a turn to recover from. `middleware.ts` covers the last
+   * guess — the bare root under curl.
+   */
+  async rewrites() {
+    return ["/agents.md", "/AGENTS.md", "/agents.txt", "/cli.md"].map((source) => ({
+      source,
+      destination: "/llms.txt",
+    }));
+  },
 };
 
 export default nextConfig;

--- a/apps/landing/public/llms.txt
+++ b/apps/landing/public/llms.txt
@@ -1,64 +1,106 @@
-# Supersonic
+# Bay
 
-> A cloud for small software. One command turns an app on your user's computer into a real, live product on the internet — database, custom domain, and monitoring included. Supersonic is built to be operated by coding agents (Claude Code, Cursor, OpenAI Codex, opencode, Cline) on the user's behalf.
+> A cloud for small software. One command turns an app on your user's computer into a real, live product on the internet — database, custom domain, and monitoring included. Bay is built to be operated by coding agents (Claude Code, Cursor, OpenAI Codex, opencode, Cline) on the user's behalf.
 
-If you are a coding agent asked to publish a user's app to Supersonic, follow "Publish an app" below. Keep the user informed, getting the deploy green is your job rather than theirs, and take secret values from the project's local `.env` instead of asking. Never invent, hardcode, commit, or print a secret value.
+You are reading the manual. It is what this address answers with when the thing
+asking is not a browser: `curl thebay.cloud` prints this file, and so do
+`/llms.txt`, `/agents.md` and `/cli.md`. Everything below happens in a terminal.
+Nothing below needs the dashboard.
+
+If you are a coding agent asked to publish a user's app to Bay, follow "Publish an app" below. Keep the user informed, getting the ship green is your job rather than theirs, and take secret values from the project's local `.env` instead of asking. Never invent, hardcode, commit, or print a secret value.
 
 ## Publish an app
 
 From the project's root folder:
 
-    npm i -g supersonic-cli    # install the CLI (once)
+    npm i -g bay-cli    # install the CLI (once)
+    bay ship --wait     # publish this folder, and WAIT for the answer
 
-Then deploy, and WAIT for the answer:
+That is the whole path. There is no separate login or signup step to run: the
+first `ship` opens a browser once, the user approves, and the ship continues
+in the same command. A new account is free, with no card and no time limit.
+(`bay deploy` is the same command under its older name, and `supersonic` is
+still installed as an alias of `bay`. Neither is deprecated: they are what
+every script and agent prompt written before the rename already says.)
 
-    # 1. Work out the PRODUCTION run command — how the app should run once deployed,
-    #    binding 0.0.0.0 and the $PORT the platform injects:
-    #      FastAPI → uvicorn main:app --host 0.0.0.0 --port $PORT
-    #      Flask   → gunicorn app:app --bind 0.0.0.0:$PORT
-    #      Django  → gunicorn <proj>.wsgi --bind 0.0.0.0:$PORT
-    #      Next    → next start        Node/Express → node server.js (must read process.env.PORT)
-    # 2. Pass it with --run. Supersonic reserves the URL immediately — the address is
-    #    live and shows the build happening — and runs the app there when it is ready.
-    supersonic deploy --wait
-
-Supersonic reads the repo itself and works out how to install, build, and run the app —
+Bay reads the repo itself and works out how to install, build, and run the app —
 including the production run command (Python, Node, static SPAs, and databases all
-handled). You do NOT need to tell it how to run the app; `supersonic deploy --wait` with
+handled). You do NOT need to tell it how to run the app; `bay ship --wait` with
 no other flags is the normal path.
 
 One optional flag, only if you want it:
 - `--run "<production command>"` — an OVERRIDE. Pass it only if you know a quirk the
   platform can't infer (an unusual monorepo entrypoint, a custom server). When present it
-  wins; when absent Supersonic decides. Example: `--run "uvicorn main:app --host 0.0.0.0 --port $PORT"`.
+  wins; when absent Bay decides. Example: `--run "uvicorn main:app --host 0.0.0.0 --port $PORT"`.
+  The command must bind `0.0.0.0` and the `$PORT` the platform injects —
+  FastAPI `uvicorn main:app --host 0.0.0.0 --port $PORT`, Flask
+  `gunicorn app:app --bind 0.0.0.0:$PORT`, Django `gunicorn <proj>.wsgi --bind 0.0.0.0:$PORT`,
+  Next `next start`, Node `node server.js` reading `process.env.PORT`.
 
-`supersonic deploy`:
+What `ship` prints, and what each line means:
 
-- Signs the user in the FIRST time by opening a browser — a new account is free, with no card and no time limit. There is NO separate login/signup step to run.
-- Prints `✓ your app is live at <url>` immediately — that is the URL being RESERVED, not the app being built.
-- With `--wait` it stays attached and prints `✓ live: <url>` when the real build serves that URL. Report that.
+- `✓ your app is live at <url>` — the address being RESERVED, not the app being built.
+  It answers immediately and draws the build happening on itself while it runs.
+- `✓ live: <url>` — the real build is now serving that address. This one, and only
+  this one, means the ship succeeded.
 
-USE `--wait`. Without it the command returns as soon as the URL is reserved and the build finishes after you have stopped watching — so you would report success for a build that has not happened, and a failure would land in `~/.supersonic/deploys/<app>.log` where nobody looks.
+USE `--wait`. Without it the command returns as soon as the URL is reserved and the build finishes after you have stopped watching — so you would report success for a build that has not happened, and a failure would land in `~/.bay/deploys/<app>.log` where nobody looks.
 
-IMPORTANT: the deploy succeeded only when you see `✓ live:`. Anything else is not done. Run `supersonic logs <app>` to see what production actually saw and `supersonic diagnose <app>` for a fix-prompt, apply it, and deploy again.
+Every app is PRIVATE until the user says otherwise, so the URL asks them to sign in. That is the default, not a broken ship — tell the user the app is live and private, and that `bay share <app> public` opens it to anyone with the link.
 
-Every app is PRIVATE until the user says otherwise, so the URL asks them to sign in. That is the default, not a broken deploy — tell the user the app is live and private, and that they can make it public in the dashboard.
+If the user is over their plan's limit, `bay ship` exits with a clear message telling them to pick a plan at https://app.supersonic.cv — relay that; it is not a build failure.
 
-If the user is over their plan's limit, `supersonic deploy` exits with a clear message telling them to pick a plan at https://app.supersonic.cv — relay that; it is not a build failure.
-
-The project's local `.env` / `.env.local` travels with the deploy automatically — the CLI
+The project's local `.env` / `.env.local` travels with the ship automatically — the CLI
 reads it, holds the FILES back from the upload, and sends the values to be stored as
 secrets. You do not need to copy keys across. Use `env set` only for a value that is not
 in `.env` at all:
 
-    supersonic env <app> set KEY=VALUE
+    bay env <app> set KEY=VALUE
 
-Skip `DATABASE_URL` and anything pointing at localhost — Supersonic provisions the
+Skip `DATABASE_URL` and anything pointing at localhost — Bay provisions the
 database and injects that itself. Ask the user only for a key that is missing locally or
 is clearly a placeholder or test value (`sk_test_…`, `changeme`), and ask in one sentence:
 what it is and where to get it.
 
-## The deploy contract
+## Before you ship, two seconds of local work
+
+`init` and `check` touch no cloud, run no build, call no model, and take about two
+seconds each. They are the loop to be in while authoring a `supersonic.json` —
+because the same loop through a real ship is eleven minutes long.
+
+    bay init [dir] [--force]   # write a DRAFT supersonic.json read out of this repo
+    bay check [dir]            # resolve and validate it, and print what each phase runs
+
+`init` writes a draft, not an answer: the monorepo split, the install command from the
+lockfile, the build command and output directory, the start command bound to `$PORT`,
+the runtime version the manifests ask for, and the framework — then it prints what it
+could not determine (which service owns `/`, whether a migration runs before traffic,
+SPA fallback, which env var names are secrets), because none of those are answerable
+from files and a guess would be indistinguishable from a decision. Correct the draft;
+don't author from nothing. It refuses to overwrite an existing config without `--force`.
+
+`check` exits non-zero on any problem, which makes it the right thing to put in front
+of a ship in CI or in an agent loop.
+
+## When a ship is not green
+
+    bay logs <app> [--severity error] [--limit 50] [--since 1h] [--follow]
+    bay errors <app>                       # errors production actually caught, last 7 days
+    bay diagnose <app> [--error "..."]     # a fix-prompt written for you to act on
+    bay patch <app>                        # the repair agent's diff, ready to pipe into `git apply`
+    bay exec <app> -- <command>            # run one command against a copy of the app's environment
+    bay rollback <app>                     # back to the previous version
+
+The order that works: `logs` to see what production saw, `diagnose` for the fix,
+apply it, `bay ship --wait` again. `patch` is the same fix as a diff when you
+would rather apply it than read it. Deploy output is also appended to
+`~/.bay/deploys/<app>.log`, so a build survives the terminal it started in.
+
+`exec` and `rollback` are not available for an app running on a node — `exec`
+answers 501 and says so, and a node keeps one version rather than a history, so
+reship the commit you want instead.
+
+## What ships, and what it takes
 
 - Any language ships if the project has a Dockerfile that listens on `$PORT`. The app's own
   Dockerfile is used as written, from the repository root when it copies paths outside its
@@ -66,35 +108,113 @@ what it is and where to get it.
 - If the app has MIGRATIONS, something in the repo has to say how to run them: a `release:`
   line in a Procfile, a compose service the app waits to finish, `fly.toml`'s
   `release_command`, `render.yaml`'s `preDeployCommand`, or a `prestart` script in
-  package.json. Without one the app deploys against an empty schema, serves its homepage,
+  package.json. Without one the app ships against an empty schema, serves its homepage,
   and fails every request that touches data.
 - Common stacks (Next.js, Vite, Node, Python, Go, ...) work without a Dockerfile.
 - Next.js and other build-then-serve apps are built automatically before serving.
-- No git or GitHub required — deploys go straight from the local folder. Re-running `supersonic deploy` in the same folder redeploys the same app (same URL, same database).
+- No git or GitHub required — a ship goes straight from the local folder. Re-running `bay ship` in the same folder reships the same app (same URL, same database).
 
-## CLI commands
+## Every command
 
-- `supersonic deploy` — URL-first: the live link now, showing the build as it happens; the real build lands on the same URL (auto sign-in the first time)
-- `supersonic deploy --github [--repo <url>]` — publish from a git URL instead
-- `supersonic deploy --prebuilt` — build locally and upload the result (old path)
-- `supersonic apps` — list the user's apps
-- `supersonic status <app>` — version, URL, database, environment
-- `supersonic logs <app>` — production logs (`--follow` to stream)
-- `supersonic errors <app>` — errors caught in production
-- `supersonic diagnose <app>` — an AI fix-prompt for the latest error
-- `supersonic env <app> set KEY=VALUE` — set environment variables
-- `supersonic exec <app> -- <command>` — run a command in a copy of the app's environment.
-  Not available for an app running on a node; it answers 501 and says so.
-- `supersonic rollback <app>` — roll back to the previous version. Same: not wired up for
-  an app on a node, which keeps one version rather than a history. Redeploy the commit you
-  want instead.
-- `supersonic login` — sign in manually (deploy does this automatically)
-- Add `--json` to any command for machine-readable output.
+Setup
+
+- `bay signup` — create an account (opens a browser, once)
+- `bay login [--url <u>] [--token <t>]` — sign in; `ship` does this for you
+- `bay logout`
+- `bay whoami` — which account, which control plane, which plan
+
+Ship
+
+- `bay ship` — URL-first: the live link now, the build drawn on it, the real build landing on the same address
+- `bay ship --wait` — stay attached and stream the build. Use this.
+- `bay ship --name <name>` — what to call it (default: this folder's name)
+- `bay ship --run "<cmd>"` — override the production run command
+- `bay ship --no-env` — do not carry `.env` up
+- `bay ship --github [--repo <url>]` — publish from GitHub or a git URL instead of this folder
+- `bay ship --prebuilt` — build here and upload the result (the older path)
+- `bay reship <app>` — rebuild from the app's own source
+- `bay delete <app> --yes` — delete an app. No prompt and no undo; the flag is the confirmation.
+
+Inspect
+
+- `bay apps` — the user's apps
+- `bay status <app>` — version, URL, environment, database
+- `bay logs <app>` / `errors <app>` / `diagnose <app>` / `patch <app>`
+- `bay exec <app> -- <command>`
+- `bay open <app>` — open it in a browser
+
+Configure
+
+- `bay env <app>` — list the env var KEYS (never the values)
+- `bay env <app> set KEY=VALUE [KEY2=VALUE2]`
+- `bay env <app> unset KEY [KEY2]`
+
+Who can open it
+
+- `bay share <app>` — the visibility, the people, the rules, and anyone waiting to be let in
+- `bay share <app> private|shared|public`
+- `bay share <app> add ada@acme.com` — one person, who gets an email
+- `bay share <app> add @acme.com` — everyone with an address there. A rule admits
+  VERIFIED addresses only (Google, or a verified GitHub address), so somebody who
+  signed up with a password at that domain is still refused.
+- `bay share <app> remove <email|@domain>`
+
+Its own address
+
+- `bay domains <app>` — what is attached, and the one DNS record to create
+- `bay domains <app> add acme.com` — the record it prints comes from the server, so it
+  is the right one for an apex or a subdomain without you having to decide
+- `bay domains <app> remove acme.com`
+
+Its data
+
+- `bay db <app>` — the tables, with row counts
+- `bay db <app> <table> [--limit 50] [--offset 0]`
+- `bay db <app> --sql "select ..."` — one read-only statement. SELECT only, one
+  statement, enforced by the server rather than by convention.
+
+Shipping from GitHub
+
+- `bay git <app>` — the repo it follows, and whether a push ships
+- `bay git <app> --branch main --auto on`
+- `bay git <app> disconnect`
+
+The account
+
+- `bay plan` — the plan, every limit, and how much of each is left. This is the
+  answer to every 402 the API returns, and it costs a second — ask it before
+  starting an eleven-minute build.
+- `bay tokens` — every CLI signed in to this account
+- `bay tokens revoke <id>`
+
+`bay help --all` prints this same list from the installed version, which is
+the copy to trust if the two ever disagree.
+
+## Running without a browser (CI, containers, a headless agent)
+
+The browser handshake exists for a person at a keyboard. Where there isn't one:
+
+    export BAY_TOKEN=<token>            # takes precedence over anything saved
+    bay ship --wait
+
+The user mints a token at https://app.supersonic.cv/cli — that page also lists
+every CLI already authorized on the account and revokes any of them. Otherwise
+`bay login --token <token>` saves it to `~/.bay/config.json`, and `BAY_URL`
+points the CLI at a different control plane. The old spellings —
+`SUPERSONIC_TOKEN`, `SUPERSONIC_URL`, and an existing `~/.supersonic/config.json`
+— are still read, so nothing that already works stops working.
+
+## Machine-readable output
+
+`--json` works on every command that returns data, and it is the flag to use when
+something else is going to read the output. Data goes to stdout, progress and
+diagnostics go to stderr, so `bay status app --json | jq .url` is clean
+without redirecting anything. A non-zero exit means the command failed.
 
 ## Plans
 
 - Free: 3 apps. No card, no time limit.
-- Pro ($20/mo): unlimited apps, and Autopilot — failed deploys fix themselves and redeploy to green.
+- Pro ($20/mo): unlimited apps, and Autopilot — a failed ship fixes itself and reships to green.
 - Team: hand-priced, talk to us.
 
 People the user shares an app with are never charged.
@@ -103,4 +223,5 @@ People the user shares an app with are never charged.
 
 - App: https://app.supersonic.cv
 - Sign up: https://app.supersonic.cv/signup
-- This manual: https://supersonic.cv/llms.txt
+- Authorize a CLI: https://app.supersonic.cv/cli
+- This manual: https://thebay.cloud/llms.txt (or just `curl thebay.cloud`)

--- a/apps/web/app/api/apps/[slug]/domains/route.ts
+++ b/apps/web/app/api/apps/[slug]/domains/route.ts
@@ -12,6 +12,7 @@ import {
 import { reconcileAll, reconcileDomain, liveAttachDeps } from "@/lib/domain-attach";
 import { removeDomainCert, EDGE_IP } from "@/lib/domain-cert";
 import { rootDomain } from "@/lib/roots";
+import { recordFor } from "@/lib/dns-record";
 
 /**
  * The domains attached to one app: read them, attach one, detach one.
@@ -35,7 +36,7 @@ async function ownedApp(slug: string) {
  * Google project; they are ours, they mean nothing to the person, and a field a
  * page does not use is a field that leaks the day someone logs the payload.
  */
-function forPage(d: AppDomain) {
+function forPage(d: AppDomain, dns: { ip: string; cname: string }) {
   return {
     hostname: d.hostname,
     status: d.status,
@@ -43,6 +44,16 @@ function forPage(d: AppDomain) {
     checkedAt: d.checkedAt,
     createdAt: d.createdAt,
     liveAt: d.liveAt,
+    // The one record to create for THIS hostname, decided here.
+    //
+    // The dashboard computes it in the browser from `dns` and `lib/dns-record`,
+    // and could go on doing that alone — but the CLI cannot. It would have to
+    // carry its own copy of the apex-versus-subdomain rule, and that copy would
+    // agree on the day it was written and disagree the first time the two-level
+    // suffix list grows: a person told to create a CNAME at an apex, by us, for
+    // a domain their registrar will refuse. One rule, one file, sent to whoever
+    // asks.
+    record: recordFor(d.hostname, dns),
   };
 }
 
@@ -74,9 +85,10 @@ export async function GET(_req: Request, { params }: { params: { slug: string } 
   // load generator.
   const domains = await reconcileAll(await listDomains(slug));
   const ent = await entitlement(app.owner_id);
+  const dns = dnsInstructions(slug);
   return Response.json({
-    domains: domains.map(forPage),
-    dns: dnsInstructions(slug),
+    domains: domains.map((d) => forPage(d, dns)),
+    dns,
     allowed: ent.limits.customDomains,
     // A private app cannot answer for a custom domain the way it answers for its
     // supersonic.cv address: the session cookie that proves who a visitor is is
@@ -135,6 +147,7 @@ export async function POST(req: Request, { params }: { params: { slug: string } 
   const next = await reconcileDomain(attached.domain, liveAttachDeps);
   await recordDomain(hostname, next);
 
+  const dns = dnsInstructions(slug);
   return Response.json({
     domain: forPage({
       ...attached.domain,
@@ -142,8 +155,8 @@ export async function POST(req: Request, { params }: { params: { slug: string } 
       detail: next.detail,
       checkedAt: Date.now(),
       liveAt: next.status === "live" ? Date.now() : attached.domain.liveAt,
-    }),
-    dns: dnsInstructions(slug),
+    }, dns),
+    dns,
   });
 }
 

--- a/apps/web/app/cli/page.tsx
+++ b/apps/web/app/cli/page.tsx
@@ -99,10 +99,10 @@ function CliAuth() {
   return (
     <div style={{ position: "relative", zIndex: 1, maxWidth: 480, margin: "14vh auto 8vh", padding: "0 24px", fontFamily: "var(--mono, ui-monospace, monospace)" }}>
       <div style={{ border: line, background: "var(--card)", padding: 30 }}>
-        <div style={{ fontSize: 12, letterSpacing: 2, color: "var(--ink-2)", marginBottom: 8 }}>SUPERSONIC / CLI</div>
+        <div style={{ fontSize: 12, letterSpacing: 2, color: "var(--ink-2)", marginBottom: 8 }}>BAY / CLI</div>
         <h1 style={{ fontSize: 22, margin: "0 0 12px", color: "var(--ink)" }}>Authorize the CLI</h1>
         <p style={{ fontSize: 13, lineHeight: 1.6, color: "var(--ink-2)", margin: "0 0 18px" }}>
-          This connects <b style={{ color: "var(--ink)" }}>{name}</b> to your Supersonic account so your coding agent can deploy and manage apps from the terminal.
+          This connects <b style={{ color: "var(--ink)" }}>{name}</b> to your Bay account so your coding agent can ship and manage apps from the terminal.
         </p>
 
         <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12, padding: "10px 12px", border: line, background: "var(--paper)", marginBottom: 22 }}>
@@ -135,7 +135,7 @@ function CliAuth() {
           <div>
             <p style={{ fontSize: 13, marginBottom: 8, color: "var(--ink)" }}>✓ Token created — paste this into your terminal:</p>
             <code style={{ display: "block", padding: 12, background: "var(--paper)", border: line, wordBreak: "break-all", fontSize: 12, color: "var(--ink)" }}>
-              supersonic login --token {token}
+              bay login --token {token}
             </code>
           </div>
         )}

--- a/apps/web/app/new/page.tsx
+++ b/apps/web/app/new/page.tsx
@@ -16,21 +16,21 @@ function asReason(v: unknown): PaywallReason {
   return REASONS.includes(v as PaywallReason) ? (v as PaywallReason) : "choose_plan";
 }
 
-const AGENT_PROMPT = `You are publishing my app to Supersonic — a cloud for small software (agent manual: https://supersonic.cv/llms.txt). Run everything from my project's root folder, and keep me posted in plain language — I don't read logs.
+const AGENT_PROMPT = `You are publishing my app to Bay — a cloud for small software (agent manual: https://thebay.cloud/llms.txt, or just curl thebay.cloud). Run everything from my project's root folder, and keep me posted in plain language — I don't read logs.
 
-1. Install the CLI if it isn't already:  npm i -g supersonic-cli
+1. Install the CLI if it isn't already:  npm i -g bay-cli
 
 2. Publish it, and WAIT for the answer:
-   supersonic deploy --wait
+   bay ship --wait
    The first run opens a browser for me to sign in. Without --wait the command returns the moment the URL is reserved and finishes building after you have stopped watching, so you would report success for a build that has not happened yet.
 
-3. The deploy succeeded only when you see a line starting "✓ live:". Anything else is not done. Getting it green is your job, not mine:  supersonic logs <app>  shows what production actually saw and  supersonic diagnose <app>  hands you a fix. Fix the code, redeploy, repeat. Don't paste me an error and ask what to do.
+3. The ship succeeded only when you see a line starting "✓ live:". Anything else is not done. Getting it green is your job, not mine:  bay logs <app>  shows what production actually saw and  bay diagnose <app>  hands you a fix. Fix the code, ship again, repeat. Don't paste me an error and ask what to do.
 
-4. The URL will ask me to sign in — every app is private until I say otherwise. That is not a bug; tell me the app is live and private, and that I can make it public in the dashboard.
+4. The URL will ask me to sign in — every app is private until I say otherwise. That is not a bug; tell me the app is live and private, and that  bay share <app> public  opens it to anyone with the link.
 
-My .env travels with the deploy automatically — you do not need to copy keys across. Use  supersonic env <app> set KEY=VALUE  only for a value that is NOT in my .env. Skip DATABASE_URL and anything pointing at localhost: Supersonic provisions the database and injects that itself.
+My .env travels with the ship automatically — you do not need to copy keys across. Use  bay env <app> set KEY=VALUE  only for a value that is NOT in my .env. Skip DATABASE_URL and anything pointing at localhost: Bay provisions the database and injects that itself.
 
-If my app has migrations and nothing in the repo says how to run them — no Procfile release line, nothing in compose.yml, fly.toml or package.json — say so and add one. An app deployed against an empty schema serves its homepage and fails everything else.
+If my app has migrations and nothing in the repo says how to run them — no Procfile release line, nothing in compose.yml, fly.toml or package.json — say so and add one. An app shipped against an empty schema serves its homepage and fails everything else.
 
 If a key is missing or is obviously a placeholder (sk_test_…, "changeme"), ask me for the real one in one sentence: what it is and where I get it. Never invent, hardcode, commit, or print a secret value.`;
 

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -95,10 +95,10 @@ export default function Settings() {
 
           {/* CLI tokens */}
           <div className="set-card">
-            <div className="set-head"><Terminal size={15} /><div><div className="st">CLI tokens</div><div className="ss">Tokens your coding agent uses with the <span className="mono">supersonic</span> CLI. Revoke any you don&apos;t recognize.</div></div></div>
+            <div className="set-head"><Terminal size={15} /><div><div className="st">CLI tokens</div><div className="ss">Tokens your coding agent uses with the <span className="mono">bay</span> CLI. Revoke any you don&apos;t recognize.</div></div></div>
             <div className="env-list">
               {tokens === null && <div className="env-empty">Loading…</div>}
-              {tokens?.length === 0 && <div className="env-empty">No CLI tokens yet. Run <span className="mono">supersonic login</span> to create one.</div>}
+              {tokens?.length === 0 && <div className="env-empty">No CLI tokens yet. Run <span className="mono">bay login</span> to create one.</div>}
               {tokens?.map((t) => (
                 <div className="env-row" key={t.id}>
                   <span className="ek">{t.name || "token"}</span>

--- a/apps/web/components/ShipNew.tsx
+++ b/apps/web/components/ShipNew.tsx
@@ -95,7 +95,7 @@ export function ShipNew() {
   const prompt = useMemo(
     () =>
       `Install the Bay CLI and ship this folder as "${chosen}":\n\n` +
-      `  npm i -g supersonic-cli && supersonic deploy --name ${chosen} --wait\n\n` +
+      `  npm i -g bay-cli && bay ship --name ${chosen} --wait\n\n` +
       `It opens a browser once to sign you in, then prints the address the app is live on.\n` +
       `Without --wait it returns before the build has finished.`,
     [chosen],

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## Unreleased
+
+**The command is `bay`, and the package is `bay-cli`.**
+
+The product is Bay and the domain is thebay.cloud, so the thing you type is
+`bay ship`. Everything about the old name keeps working, and none of it is
+deprecated: the package still installs a `supersonic` binary, `~/.supersonic`
+is still read when it is the directory that exists, and `SUPERSONIC_TOKEN`,
+`SUPERSONIC_URL` and `SUPERSONIC_WHO` are still honoured beside `BAY_TOKEN`,
+`BAY_URL` and `BAY_WHO`. A rename that silently stops reading a token file
+does not read as a rename — it reads as the platform signing you out — so the
+migration is: use the new name if it is there, otherwise keep using theirs.
+`lib/home.js` holds that rule and `test/home.test.js` pins it.
+
+Not renamed, deliberately: `supersonic.json`, the `x-supersonic-*` headers,
+`SUPERSONIC_RUN`, `SUPERSONIC_CODE_*`, and the encryption salt. Those are read
+by the CONTROL PLANE rather than typed by a person, and moving them from this
+side would break every ship against a server that has not moved with them.
+
+**Everything the dashboard does, the CLI does.**
+
+`bay share` (visibility, people, and `@company` rules), `bay domains` (attach a
+domain you own and print the one DNS record to create), `bay db` (tables, rows,
+one read-only SELECT), `bay git` (which branch, and whether a push ships),
+`bay plan` (the plan and every limit left) and `bay tokens` (every CLI signed
+in to the account, and revoking one). No new endpoints were needed: the control
+plane resolves a Bearer token wherever it resolves a session cookie.
+
+The DNS record comes from the server rather than being derived here. Apex versus
+subdomain is a public-suffix question, and a second copy of that rule would agree
+until the day the list grew — then tell somebody to create a CNAME their
+registrar refuses.
+
+**Fixed: `check` claimed every service started from a Dockerfile.**
+
+It printed "start · the Dockerfile's own CMD" for every non-static service,
+because it asked whether the lane was `container` — and after the buildpack
+lane was removed, `container` means all of them. So a repository with no
+Dockerfile, whose start command is stated in the config in plain text, had that
+command hidden by the one command whose job is to say what will run. It reads
+the author's Dockerfile now.
+
+**Fixed: `open` and `status` knew exactly one domain.**
+
+Both built `https://<app>.supersonic.cv` in the published package — a URL that
+survives a rebrand, ignores every attached domain, and can only be corrected by
+a release. They ask the API for the app's own address.
+
 ## 0.12.1
 
 **A ship now says who is shipping.**

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,32 +1,42 @@
-# supersonic-cli
+# bay-cli
 
-Deploy anything to [Supersonic](https://app.supersonic.cv) in one command.
+Ship anything to [Bay](https://thebay.cloud) in one command.
 
 ```bash
-npm install -g supersonic-cli
+npm install -g bay-cli
 ```
+
+The command is `bay`. It also installs as `supersonic`, which is the name it had
+before and which every existing script, CI job and agent prompt still says — that
+alias is permanent, not deprecated.
 
 ## Usage
 
 ```bash
-supersonic init                  # write a DRAFT supersonic.json from this repo
-supersonic check                 # what each phase would run, and what would fail
-supersonic login                 # authenticate (defaults to app.supersonic.cv)
-supersonic deploy                # deploy the current repo (uses your git origin)
-supersonic deploy --repo <url>   # or deploy any public git repo
-supersonic whoami
-supersonic logout
+bay init                  # write a DRAFT supersonic.json from this repo
+bay check                 # what each phase would run, and what would fail
+bay login                 # authenticate (defaults to app.supersonic.cv)
+bay ship                  # ship this folder — a live URL now, the build behind it
+bay ship --github         # or ship from your git origin / any public repo
+bay whoami
+bay logout
 ```
 
-`supersonic deploy` streams the live build log — clone → detect stack → build → Cloud Run — and prints your live URL when it's up.
+`bay ship --wait` streams the live build — clone → detect stack → build → run — and
+prints the live URL when the app is actually serving it. `bay deploy` is the same
+command under its older name and always will be.
 
-## Before you deploy
+Everything the dashboard does, this does: `bay share` (who can open it),
+`bay domains` (a domain you own, and the DNS record to create), `bay db`,
+`bay git` (branch + ship-on-push), `bay plan`, `bay tokens`. Run `bay help --all`.
+
+## Before you ship
 
 `init` and `check` are local. No cloud, no build, no model, about two seconds each,
 and they are the loop an agent authoring a `supersonic.json` should be in — because
-the same loop through a real deploy is eleven minutes long.
+the same loop through a real ship is eleven minutes long.
 
-`supersonic init` reads the repository and writes a **draft** `supersonic.json`: the
+`bay init` reads the repository and writes a **draft** `supersonic.json`: the
 monorepo split, the install command from the lockfile, the build command and output
 directory, the start command bound to `$PORT`, the runtime version the manifests ask
 for, and the framework. Then it prints what it could not determine — which service
@@ -35,7 +45,7 @@ names are secrets — because none of those are answerable from files, and a gue
 would be indistinguishable from a decision. It refuses to overwrite an existing
 config without `--force`.
 
-`supersonic check` resolves and validates that file exactly as a deploy would, and
+`bay check` resolves and validates that file exactly as a deploy would, and
 prints, per service, the command each phase runs. Non-zero exit on any problem.
 
 Both go through `vendor/resolve.js`, which is `apps/web/lib/{resolve,app-config,
@@ -47,7 +57,14 @@ after the runner had moved to 3.14.
 
 ## Options
 
-- `supersonic login --url <control-plane>` — point at a different control-plane (defaults to `https://app.supersonic.cv`; also settable via `SUPERSONIC_URL`).
-- `supersonic login --email <e>` — skip the email prompt. Password can be piped via `SUPERSONIC_PASSWORD`.
+- `bay login --url <control-plane>` — point at a different control-plane (defaults to `https://app.supersonic.cv`; also settable via `BAY_URL`).
+- `bay login --token <t>` — for CI and headless agents. `BAY_TOKEN` in the environment does the same and overrides anything saved.
 
-Your session is stored in `~/.supersonic/config.json`.
+Your session is stored in `~/.bay/config.json`. An existing `~/.supersonic/config.json`
+is still read, so an upgrade does not sign anybody out — and `SUPERSONIC_URL` /
+`SUPERSONIC_TOKEN` are still honoured alongside the `BAY_` names.
+
+What is deliberately NOT renamed: the config file is still `supersonic.json`, and the
+`x-supersonic-*` headers, `SUPERSONIC_RUN` and `SUPERSONIC_CODE_*` are still what they
+were. Those are read by the control plane, not typed by a person; they change when the
+server changes, not before.

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -2,10 +2,26 @@
 "use strict";
 
 /*
- * supersonic — the deploy/debug surface for a coding agent.
+ * bay — the ship/debug surface for a coding agent.
  * Designed for agents, not humans: no interactive prompts, --json everywhere,
  * token auth (a human logs in once, the agent inherits the token), stdout=data,
  * stderr=logs, meaningful exit codes.
+ *
+ * THE OLD NAME STILL WORKS, EVERYWHERE, AND IS NOT DEPRECATED.
+ *
+ * The command is `bay`; package.json also installs it as `supersonic`. The
+ * config is ~/.bay; ~/.supersonic is still read. The variables are BAY_TOKEN and
+ * BAY_URL; SUPERSONIC_TOKEN and SUPERSONIC_URL are still honoured. Every one of
+ * those pairs exists because the old spelling is written into scripts, CI
+ * configs and agent prompts that nobody is going to edit, and a rename that
+ * silently stops reading them does not read as a rename — it reads as the
+ * platform signing you out and losing your account.
+ *
+ * The wire is a different question and the answer is no. `x-supersonic-*`
+ * headers, `SUPERSONIC_RUN`, `SUPERSONIC_CODE_BUCKET` and `supersonic.json` are
+ * what the CONTROL PLANE reads, not what a person types. Renaming them here
+ * would break every deploy against a server that has not been renamed on the
+ * same afternoon, so they stay until the server moves first.
  */
 
 const fs = require("fs");
@@ -17,13 +33,34 @@ const { readEnvFiles, selectEnv, encodeEnvHeader } = require("./lib/envfile");
 const { joinExecArgs } = require("./lib/exec-args");
 const { whoHeader } = require("./lib/who");
 const { deletionRefusal } = require("./lib/confirm");
+const { configDirIn, envVarFrom } = require("./lib/home");
 
-const CFG_DIR = path.join(os.homedir(), ".supersonic");
+/**
+ * Where the session lives: ~/.bay, unless ~/.supersonic is the one that exists.
+ *
+ * Not "read both and merge" — that would have two files disagreeing about which
+ * account you are, with the winner decided by the order of two lines. The rule
+ * is: the new directory if it is there, otherwise the old one if IT is there,
+ * otherwise the new one. So an existing user stays signed in and keeps writing
+ * to the file they already have, and a new one never creates the old name.
+ */
+const CFG_DIR = configDirIn(os.homedir(), fs.existsSync, path.join);
 const CFG = path.join(CFG_DIR, "config.json");
 const DEFAULT_URL = "https://app.supersonic.cv";
 
+/**
+ * A variable under its new name, falling back to the old one.
+ *
+ * `BAY_TOKEN` is the name now; `SUPERSONIC_TOKEN` is what is exported in every
+ * CI job that already ships to this platform. The new name wins when both are
+ * set, which is the only sane precedence: somebody who set both was migrating.
+ */
+function envVar(name) {
+  return envVarFrom(process.env, name);
+}
+
 // ---------- output ----------
-// A reader that stops reading — `supersonic check | head -5`, an agent piping into
+// A reader that stops reading — `bay check | head -5`, an agent piping into
 // grep — closes the pipe under us, and Node turns that into an unhandled EPIPE:
 // twenty lines of stack trace printed over the output that was actually asked for,
 // and a non-zero exit that reads as the command having failed. It did not; the
@@ -34,7 +71,7 @@ const COLOR = process.stdout.isTTY && !process.env.NO_COLOR;
 const c = (n) => (s) => (COLOR ? `\x1b[${n}m${s}\x1b[0m` : String(s));
 const dim = c("2"), bold = c("1"), green = c("32"), red = c("31"), cyan = c("36"), yellow = c("33");
 // Set once a deploy knows its slug: every progress line is also appended to
-// ~/.supersonic/deploys/<slug>.log, so a build survives the terminal it was
+// <config dir>/deploys/<slug>.log, so a build survives the terminal it was
 // started in. Best-effort — a log that cannot be written must never stop a deploy.
 let deployLog = null;
 function startDeployLog(slug) {
@@ -81,14 +118,14 @@ function writeLockfile(decided, slug) {
   if (!decided || typeof decided !== "object") return;
   try {
     const body = JSON.stringify({
-      $comment: "Written by supersonic after a successful deploy. Safe to commit, safe to delete.",
+      $comment: "Written by bay after a successful ship. Safe to commit, safe to delete.",
       slug: slug || undefined,
       decided,
     }, null, 2) + "\n";
     const path = require("node:path").join(process.cwd(), LOCKFILE);
     if (require("node:fs").existsSync(path) && require("node:fs").readFileSync(path, "utf8") === body) return;
     require("node:fs").writeFileSync(path, body);
-    info(dim(`  wrote ${LOCKFILE} — what this deploy decided, so you can see it and change it`));
+    info(dim(`  wrote ${LOCKFILE} — what this ship decided, so you can see it and change it`));
   } catch { /* never fail a green deploy over a note about it */ }
 }
 function json(o) { print(JSON.stringify(o, null, 2)); }
@@ -96,13 +133,21 @@ function json(o) { print(JSON.stringify(o, null, 2)); }
 // ---------- config ----------
 function loadCfg() { try { return JSON.parse(fs.readFileSync(CFG, "utf8")); } catch { return {}; } }
 function saveCfg(cfg) { fs.mkdirSync(CFG_DIR, { recursive: true }); fs.writeFileSync(CFG, JSON.stringify(cfg, null, 2)); }
-function baseUrl() { return (process.env.SUPERSONIC_URL || loadCfg().url || DEFAULT_URL).replace(/\/$/, ""); }
-function token() { return process.env.SUPERSONIC_TOKEN || loadCfg().token || ""; }
+function baseUrl() { return (envVar("URL") || loadCfg().url || DEFAULT_URL).replace(/\/$/, ""); }
+function token() { return envVar("TOKEN") || loadCfg().token || ""; }
 
 // ---------- api ----------
-async function api(pathname, { method = "GET", body, stream = false } = {}) {
+/**
+ * @param {object} [opts]
+ * @param {boolean} [opts.quiet] Don't narrate a 200-with-an-error-field. Some
+ *   routes — the database one — answer 200 and put the failure in the body,
+ *   because for them "this database does not exist" is an answer rather than a
+ *   transport failure. Their callers print it themselves, and without this the
+ *   reader sees the same sentence twice, once dim and once red.
+ */
+async function api(pathname, { method = "GET", body, stream = false, quiet = false } = {}) {
   const tok = token();
-  if (!tok) die("not authenticated — run: supersonic login");
+  if (!tok) die("not authenticated — run: bay login");
   const res = await fetch(baseUrl() + pathname, {
     method,
     headers: {
@@ -112,12 +157,12 @@ async function api(pathname, { method = "GET", body, stream = false } = {}) {
     },
     body: body ? JSON.stringify(body) : undefined,
   });
-  if (res.status === 401) die("token invalid or expired — run: supersonic login");
+  if (res.status === 401) die("token invalid or expired — run: bay login");
   if (res.status === 403) die("forbidden — you don't own that app (or it doesn't exist)");
   if (stream) return res;
   const data = await res.json().catch(() => ({}));
   if (!res.ok && data.error) die(data.error);
-  if (data.error) info(dim("! " + data.error));
+  if (data.error && !quiet) info(dim("! " + data.error));
   return data;
 }
 
@@ -130,7 +175,7 @@ function openBrowser(url) {
 
 // ---------- commands ----------
 async function login(args) {
-  const url = (args.url || process.env.SUPERSONIC_URL || DEFAULT_URL).replace(/\/$/, "");
+  const url = (args.url || envVar("URL") || DEFAULT_URL).replace(/\/$/, "");
   // Explicit token (agents / CI / headless).
   if (args.token) {
     const ok = await validToken(url, String(args.token));
@@ -145,7 +190,7 @@ async function login(args) {
 // Create an account without leaving the terminal: opens the browser to sign up,
 // then the web hands a token back and the agent can continue straight to deploy.
 async function signup(args) {
-  const url = (args.url || process.env.SUPERSONIC_URL || DEFAULT_URL).replace(/\/$/, "");
+  const url = (args.url || envVar("URL") || DEFAULT_URL).replace(/\/$/, "");
   await loopbackAuth(url, "/signup", "signed up");
 }
 
@@ -164,7 +209,7 @@ async function runLoopback(url, startPath) {
       if (u.pathname !== "/callback") { res.writeHead(404); res.end(); return; }
       const tok = u.searchParams.get("token") || "";
       res.writeHead(200, { "Content-Type": "text/html" });
-      res.end("<body style='font-family:monospace;text-align:center;padding-top:20vh'><h2>&#10003; Supersonic CLI connected</h2><p>You can close this tab and return to your terminal.</p></body>");
+      res.end("<body style='font-family:monospace;text-align:center;padding-top:20vh'><h2>&#10003; Bay CLI connected</h2><p>You can close this tab and return to your terminal.</p></body>");
       resolve(tok);
     });
   });
@@ -188,7 +233,7 @@ async function runLoopback(url, startPath) {
 // The `login`/`signup` wrapper: authenticate, then report and exit.
 async function loopbackAuth(url, startPath, verb) {
   const tok = await runLoopback(url, startPath);
-  if (!tok) return die(`${verb} timed out — try again, or use: supersonic login --token <token>`);
+  if (!tok) return die(`${verb} timed out — try again, or use: bay login --token <token>`);
   saveCfg({ ...loadCfg(), url, token: tok });
   print(green("✓ ") + `${verb} to ${url}`);
   process.exit(0);
@@ -201,7 +246,7 @@ async function ensureAuth() {
   const url = baseUrl();
   info(dim("Not signed in — opening a browser to sign in (just this once)…"));
   const tok = await runLoopback(url, "/cli");
-  if (!tok) die("sign-in timed out — run `supersonic login`, then `supersonic deploy` again");
+  if (!tok) die("sign-in timed out — run `bay login`, then `bay ship` again");
   saveCfg({ ...loadCfg(), url, token: tok });
   info(green("✓ ") + "signed in — continuing…");
 }
@@ -221,9 +266,9 @@ async function whoami(args) {
   // just that a token exists.
   const res = await fetch(baseUrl() + "/api/account", { headers: { Authorization: "Bearer " + tok } });
   const acct = res.ok ? await res.json().catch(() => ({})) : {};
-  if (args.json) return json({ loggedIn: res.ok, url: baseUrl(), email: acct.email || null, plan: acct.plan || null, source: process.env.SUPERSONIC_TOKEN ? "env" : "config" });
-  if (!res.ok) return die("token invalid — run: supersonic login");
-  const src = process.env.SUPERSONIC_TOKEN ? "env token" : "saved token";
+  if (args.json) return json({ loggedIn: res.ok, url: baseUrl(), email: acct.email || null, plan: acct.plan || null, source: envVar("TOKEN") ? "env" : "config" });
+  if (!res.ok) return die("token invalid — run: bay login");
+  const src = envVar("TOKEN") ? "env token" : "saved token";
   const who = acct.email ? " as " + acct.email : "";
   const plan = acct.plan ? ` · ${acct.plan}` : "";
   print(`logged in to ${baseUrl()}${who}${plan} (${src})`);
@@ -238,7 +283,7 @@ async function apps(args) {
   const d = await api("/api/apps");
   const list = d.apps || [];
   if (args.json) return json(list);
-  if (!list.length) { info("no apps yet — deploy one with: supersonic deploy"); return; }
+  if (!list.length) { info("no apps yet — ship one with: bay ship"); return; }
   for (const a of list) {
     // The list endpoint has always sent `status: "building"` for a deploy in
     // flight and the CLI has always thrown it away, so an app that was building
@@ -261,7 +306,9 @@ async function status(args) {
   // answer to a question it could not yet answer.
   const dot = d.ready ? green("● live") : d.deploying ? yellow("◐ deploying") : red("○ down");
   print(`${bold(app)}  ${dot}${d.deploying && d.stage ? dim(` · ${d.stage}`) : ""}`);
-  print(dim("  url      ") + `${app}.supersonic.cv`);
+  // The server's own answer, for the same reason `open` asks for it: the root is
+  // not this file's to know.
+  print(dim("  url      ") + (d.url || `https://${app}.supersonic.cv`));
   print(dim("  revision ") + (d.revision || "—"));
   print(dim("  image    ") + (d.image ? d.image.split("/").pop() : "—"));
   print(dim("  region   ") + (d.region || "—"));
@@ -349,7 +396,7 @@ async function env(args) {
   if (sub === "set") {
     const set = {};
     for (const kv of rest) { const i = kv.indexOf("="); if (i > 0) set[kv.slice(0, i)] = kv.slice(i + 1); }
-    if (!Object.keys(set).length) die("usage: supersonic env <app> set KEY=VALUE [KEY2=VALUE2]");
+    if (!Object.keys(set).length) die("usage: bay env <app> set KEY=VALUE [KEY2=VALUE2]");
     const d = await api(`/api/apps/${app}/env`, { method: "POST", body: { set } });
     // "new revision" is Cloud Run's word, and an app on a node has none — its
     // process is restarted in place. Worse, it was printed unconditionally, so
@@ -360,7 +407,7 @@ async function env(args) {
     return;
   }
   if (sub === "unset") {
-    if (!rest.length) die("usage: supersonic env <app> unset KEY [KEY2]");
+    if (!rest.length) die("usage: bay env <app> unset KEY [KEY2]");
     const d = await api(`/api/apps/${app}/env`, { method: "POST", body: { unset: rest } });
     print(green("✓ ") + `unset ${rest.join(", ")}${d?.note ? ` — ${d.note}` : ""}`);
     if (args.json) json(d);
@@ -369,13 +416,342 @@ async function env(args) {
   die(`unknown env subcommand: ${sub}`);
 }
 
+// ---------- the rest of the platform ----------
+//
+// Everything below exists because the answer to "can I do that from the CLI?"
+// has to be yes. A command that sends someone to the dashboard for one setting
+// sends an AGENT nowhere at all: it cannot open a browser, cannot click, and
+// cannot tell its user what it could not do. Domains, access, the database, the
+// connected repository, the plan and the tokens were all dashboard-only, and
+// each of them is a place an agent-driven deploy stopped.
+//
+// None of them needed a new endpoint. The control plane resolves a Bearer token
+// exactly where it resolves a session cookie (apps/web/lib/session.ts), so every
+// route the dashboard calls already answers a CLI that asks.
+
+/**
+ * The custom domains attached to one app: read them, attach one, detach one.
+ *
+ * The DNS record is printed by `printRecord` from what the SERVER decided, never
+ * from a rule this file carries. An apex cannot be a CNAME and a subdomain
+ * should be one, and that decision lives in apps/web/lib/dns-record.ts — a copy
+ * here would agree today and, the first time its public-suffix list grows, tell
+ * somebody to create a record their registrar refuses.
+ */
+async function domains(args) {
+  const app = needApp(args);
+  const [, sub, host] = args._;
+
+  if (!sub) {
+    const d = await api(`/api/apps/${app}/domains`);
+    if (args.json) return json(d);
+    const list = d.domains || [];
+    if (!list.length) {
+      info(`no domain connected — ${bold(`bay domains ${app} add <hostname>`)}`);
+      if (d.allowed === false) info(dim("custom domains are not on this account's plan"));
+      return;
+    }
+    for (const dom of list) printDomain(dom, d.dns);
+    // Said once, under the list, and only when it is true. A private app cannot
+    // answer at a domain it does not own the cookie for — the edge sends those
+    // visitors back to the platform address — so a domain that is `live` and an
+    // app that is private is a working certificate onto a redirect.
+    if (d.visibility && d.visibility !== "public") {
+      print("");
+      info(dim(`${app} is ${d.visibility}: visitors at a custom domain are sent back to its platform address to sign in.`));
+      info(dim(`make it public with: bay share ${app} public`));
+    }
+    return;
+  }
+
+  if (sub === "add") {
+    if (!host) die(`usage: bay domains ${app} add <hostname>`);
+    const d = await api(`/api/apps/${app}/domains`, { method: "POST", body: { hostname: host } });
+    if (args.json) return json(d);
+    print(green("✓ ") + `${d.domain.hostname} is attached to ${app}`);
+    printDomain(d.domain, d.dns);
+    return;
+  }
+
+  if (sub === "remove" || sub === "rm") {
+    if (!host) die(`usage: bay domains ${app} remove <hostname>`);
+    const d = await api(`/api/apps/${app}/domains?hostname=${encodeURIComponent(host)}`, { method: "DELETE" });
+    if (args.json) return json(d);
+    print(green("✓ ") + `${host} detached — its certificate is gone, so stop pointing DNS at us`);
+    return;
+  }
+
+  die(`unknown: domains ${sub}\nusage: bay domains <app> [add <hostname> | remove <hostname>]`);
+}
+
+/** One domain, its state, and — while it is not live — the record to create. */
+function printDomain(d, dns) {
+  const state = {
+    live: () => `${green("● live")}`,
+    securing: () => `${yellow("◐ securing")} ${dim("— the certificate is being issued, usually a few minutes")}`,
+    pending_dns: () => `${yellow("○ waiting")} ${dim("— for the DNS record below")}`,
+    failed: () => `${red("✗ failed")}`,
+  }[d.status];
+  print(`${bold(d.hostname)}  ${state ? state() : dim(d.status)}`);
+  if (d.detail) print(dim("  " + d.detail));
+  if (d.status !== "live") printRecord(d, dns);
+}
+
+/**
+ * The record, as the fields a DNS panel actually asks for.
+ *
+ * `guessed` is printed rather than hidden. It means the server could not place
+ * the name against its suffix list and fell back to `A`, which works everywhere
+ * — but somebody moving a subdomain would rather know they can use a CNAME.
+ */
+function printRecord(d, dns) {
+  const r = d.record;
+  if (!r) {
+    // An older control plane, which sends `dns` without deciding the record. Both
+    // options, plainly, rather than a rule this file would have to keep.
+    if (!dns) return;
+    print(dim("  create ONE of these where your DNS is managed:"));
+    print(dim("    A     @    ") + dns.ip + dim("   (at the root of the domain)"));
+    print(dim("    CNAME <sub> ") + dns.cname + dim("   (for a subdomain)"));
+    return;
+  }
+  print(dim("  create this record where your DNS is managed:"));
+  print(dim("    type  ") + r.type);
+  print(dim("    name  ") + r.name + (r.name === "@" ? dim("   (the root of the domain)") : ""));
+  print(dim("    value ") + r.value);
+  if (r.guessed) print(dim("    (A works at any name; a subdomain could also use a CNAME to " + (dns ? dns.cname : "its platform address") + ")"));
+}
+
+/**
+ * Who can open the app: the visibility, the people, and the rules.
+ *
+ * `bay share <app>` alone shows it. Everything else is one word — a
+ * visibility, or add/remove with an address or a @domain — and the parsing is in
+ * lib/share-args.js, because reading `acme.com` as a person instead of as a
+ * company is a mistake that would not look like one afterwards.
+ */
+async function share(args) {
+  const app = needApp(args);
+  const { parseShare, shareBody } = require("./lib/share-args");
+  const action = parseShare(args._.slice(1));
+  if (action.kind === "error") die(action.why);
+
+  const path = `/api/apps/${app}/share`;
+  const d =
+    action.kind === "show" ? await api(path)
+      : action.kind === "visibility" ? await api(path, { method: "POST", body: { visibility: action.visibility } })
+        : await api(path, { method: "POST", body: shareBody(action) });
+
+  if (args.json) return json(d);
+
+  if (action.kind === "add") {
+    print(green("✓ ") + (action.audience === "email"
+      ? `${action.value} can open ${app} — they have been emailed the link`
+      : `anyone with an @${action.value} address can open ${app}`));
+  }
+  if (action.kind === "remove") print(green("✓ ") + `removed ${action.value}`);
+  printAccess(app, d);
+}
+
+function printAccess(app, d) {
+  const said = {
+    private: `${red("● private")} ${dim("— only you")}`,
+    shared: `${yellow("● shared")} ${dim("— you, and the people and rules below")}`,
+    public: `${green("● public")} ${dim("— anyone with the link, no sign-in")}`,
+  }[d.visibility];
+  print(`${bold(app)}  ${said || dim(String(d.visibility))}`);
+
+  for (const email of d.grants || []) print(dim("  person ") + email);
+  for (const domain of d.domains || []) print(dim("  rule   ") + `everyone @${domain}`);
+  // Said once, under the rules, because it is the difference between a rule that
+  // works and a person who cannot get in: a rule admits an address the identity
+  // provider PROVED — Google, or a verified GitHub address. Somebody who signed
+  // up with a password at the same domain is refused, and the page they see says
+  // to sign in with Google instead.
+  if ((d.domains || []).length) info(dim("  a rule admits verified addresses only — password signups at that domain are not let in"));
+
+  // A pending request is somebody who is currently looking at a locked door. It
+  // is the only line here that is waiting on the reader, so it says the command
+  // that answers it.
+  for (const email of d.requests || []) {
+    print(`${yellow("  asking")} ${email} ${dim(`— bay share ${app} add ${email}`)}`);
+  }
+
+  if (d.workspaceDomain && !(d.domains || []).includes(d.workspaceDomain)) {
+    info(dim(`  everyone at your company: bay share ${app} add @${d.workspaceDomain}`));
+  }
+}
+
+/**
+ * The app's database, read-only, from here.
+ *
+ * `db <app>` lists the tables, `db <app> <table>` reads rows, and `--sql`
+ * asks one SELECT. Read-only is the server's rule, not a convention this file
+ * follows: the route refuses anything that does not begin with SELECT, and
+ * refuses a second statement. Which is the right rule — a CLI that could DROP a
+ * production table on a typo'd argument is not a tool an agent should be handed.
+ */
+async function db(args) {
+  const app = needApp(args);
+  const [, table] = args._;
+  const { renderTable } = require("./lib/rows");
+
+  if (args.sql) {
+    const d = await api(`/api/apps/${app}/db`, { method: "POST", body: { sql: String(args.sql) }, quiet: true });
+    if (args.json) return json(d);
+    if (d.error) die(d.error);
+    if (!(d.rows || []).length) { info("no rows"); return; }
+    for (const l of renderTable(d.columns, d.rows)) print(l);
+    return;
+  }
+
+  if (!table) {
+    const d = await api(`/api/apps/${app}/db`, { quiet: true });
+    if (args.json) return json(d);
+    if (d.error) die(d.error);
+    const list = d.tables || [];
+    if (!list.length) { info("this database has no tables yet"); return; }
+    info(dim(d.database));
+    for (const t of list) {
+      const n = t.rowsExact ? String(t.rows) : `~${t.rows}`;
+      print(`${bold(t.name.padEnd(28))} ${dim(n.padStart(8) + " rows  " + t.columns + " cols")}`);
+    }
+    info(dim(`\nread one: bay db ${app} <table>`));
+    return;
+  }
+
+  const qs = new URLSearchParams({ table });
+  if (args.limit) qs.set("limit", String(args.limit));
+  if (args.offset) qs.set("offset", String(args.offset));
+  const d = await api(`/api/apps/${app}/db?${qs.toString()}`, { quiet: true });
+  if (args.json) return json(d);
+  if (d.error) die(d.error);
+  const names = (d.columns || []).map((c) => (typeof c === "string" ? c : c.name));
+  for (const l of renderTable(names, d.rows || [])) print(l);
+  // The count is the reason `--limit`/`--offset` exist, so it is said even when
+  // one page is the whole table.
+  const shown = (d.rows || []).length;
+  info(dim(`${shown} of ${d.totalExact ? d.total : "~" + d.total} rows${d.orderedBy ? ", " + d.orderedBy : ""}`));
+}
+
+/**
+ * The repository this app follows, and whether a push to it ships.
+ *
+ * Connecting one is still a browser flow — it installs a GitHub App, which is
+ * GitHub's consent screen and cannot be automated away. Everything after that
+ * is here: which branch, whether pushes deploy, and disconnecting.
+ */
+async function git(args) {
+  const app = needApp(args);
+  const [, sub] = args._;
+  const path = `/api/apps/${app}/git`;
+
+  if (sub === "disconnect") {
+    const d = await api(path, { method: "DELETE" });
+    if (args.json) return json(d);
+    print(green("✓ ") + `${app} no longer follows a repository — it keeps running, and reship still works`);
+    return;
+  }
+
+  const wantsBranch = typeof args.branch === "string";
+  const wantsAuto = args.auto !== undefined;
+  if (wantsBranch || wantsAuto) {
+    const body = {};
+    if (wantsBranch) body.branch = args.branch;
+    if (wantsAuto) {
+      const on = args.auto === true || /^(on|yes|true)$/i.test(String(args.auto));
+      const off = /^(off|no|false)$/i.test(String(args.auto));
+      if (!on && !off) die(`--auto takes on or off, not "${args.auto}"`);
+      body.autoDeploy = on;
+    }
+    const d = await api(path, { method: "PUT", body });
+    if (args.json) return json(d);
+    print(green("✓ ") + `${d.repo} · ${d.branch} · ${d.autoDeploy ? "ships on push" : "manual"}`);
+    return;
+  }
+
+  const d = await api(path);
+  if (args.json) return json(d);
+  if (!d.connected) {
+    info(`${app} follows no repository`);
+    info(dim(`connect one at ${baseUrl()}/apps/${app} — it installs a GitHub App, which needs a browser`));
+    return;
+  }
+  print(`${bold(d.repo)}  ${dim(d.url)}`);
+  print(dim("  branch ") + d.branch);
+  print(dim("  push   ") + (d.autoDeploy ? green("ships automatically") : "does nothing until you reship"));
+}
+
+/**
+ * The plan, and every meter that can stop a deploy.
+ *
+ * `whoami` says which account. This says what that account may still do — which
+ * is the question behind every 402 the API returns, and the one an agent should
+ * be able to answer before it starts an eleven-minute build.
+ */
+async function plan(args) {
+  const d = await api("/api/account");
+  if (args.json) return json(d);
+
+  print(`${bold(d.plan || "free")}${d.locked ? red("  · locked") : ""}${d.email ? dim("  " + d.email) : ""}`);
+  const u = d.usage || {};
+  // null is the wire form of unlimited — see the `cap()` in the account route.
+  const meter = (label, used, max) =>
+    print(dim("  " + label.padEnd(12)) + `${used ?? 0}${max === null || max === undefined ? dim(" of unlimited") : dim(" of " + max)}`);
+  meter("apps", u.apps, u.maxApps);
+  meter("public", u.publicApps, u.maxPublicApps);
+  meter("builds", u.builds, u.monthlyBuilds);
+  meter("agent runs", u.agentRuns, u.monthlyAgentRuns);
+
+  const f = d.features || {};
+  const has = (on, name) => (on ? green("✓ ") + name : dim("· " + name));
+  print("  " + [has(f.autoFix, "auto-fix"), has(f.customDomains, "custom domains"), has(f.canRemoveBadge, "badge off")].join("   "));
+  info(dim(`\nchange plan: ${baseUrl()}/settings`));
+}
+
+/**
+ * Every CLI holding a key to this account, and the way to take one back.
+ *
+ * A token is minted in a browser — that is the whole point of the loopback flow
+ * — but revoking one must not need the same browser. A laptop that is gone, a CI
+ * runner that was decommissioned, a token pasted into the wrong terminal: those
+ * are moments when a person wants one command, not a dashboard.
+ */
+async function tokens(args) {
+  const [sub, id] = args._;
+
+  if (sub === "revoke") {
+    if (!id) die("usage: bay tokens revoke <id>   (ids come from: bay tokens)");
+    const d = await api("/api/account/tokens", { method: "POST", body: { revoke: id } });
+    if (args.json) return json(d);
+    // `ok` is read rather than assumed. This route answers 404 for an id that is
+    // not yours, which `api` turns into a refusal — but its sibling
+    // /api/cli/token answers 200 with `ok: false` for the same case, and a
+    // command that printed ✓ on that would be telling somebody a key had been
+    // taken back when it had not.
+    if (d.ok === false) die(`no token ${id} on this account — check: bay tokens`);
+    print(green("✓ ") + `revoked ${id} — that CLI is signed out`);
+    return;
+  }
+
+  const d = await api("/api/account/tokens");
+  const list = d.tokens || [];
+  if (args.json) return json(list);
+  if (!list.length) { info("no CLI tokens on this account"); return; }
+  for (const t of list) {
+    const last = t.last_used_at ? new Date(t.last_used_at).toISOString().slice(0, 10) : "never";
+    print(`${dim(t.id)}  ${bold((t.name || "cli").padEnd(20))} ${dim("added " + String(t.created_at).slice(0, 10) + " · last used " + last)}`);
+  }
+  info(dim("\nrevoke one: bay tokens revoke <id>"));
+}
+
 /**
  * The repair agent's fix, as a patch, on stdout and nothing else.
  *
  * The agent's edits happen in the copy of the repo the server unpacked, which is
  * deleted when the deploy ends — so a rescued app left this folder still broken
  * and the next deploy shipped the same code again. Straight to stdout so it can
- * be piped: `supersonic patch <app> | git apply`. Every other word this command
+ * be piped: `bay patch <app> | git apply`. Every other word this command
  * says goes to stderr, so the pipe carries the patch alone.
  */
 async function patch(args) {
@@ -422,7 +798,7 @@ async function del(args) {
 async function exec(args) {
   const app = needApp(args);
   const command = joinExecArgs(args._raw || []);
-  if (!command) die('usage: supersonic exec <app> -- <command>   e.g. supersonic exec myapp -- node -v');
+  if (!command) die('usage: bay exec <app> -- <command>   e.g. bay exec myapp -- node -v');
   info(dim(`exec in ${app} (isolated instance, app env + db attached)`));
   info(dim("cold-starting a one-off container — can take ~30–60s…"));
   const d = await api(`/api/apps/${app}/exec`, { method: "POST", body: { command } });
@@ -432,9 +808,19 @@ async function exec(args) {
   if (d.exitCode) { info(red(`exited ${d.exitCode}`)); process.exitCode = d.exitCode; }
 }
 
+/**
+ * Open the app in a browser, at the address the SERVER says it has.
+ *
+ * This used to build `https://<app>.supersonic.cv` here. That is one root
+ * hardcoded into a published npm package: it survives a rebrand, it ignores
+ * every custom domain the app has, and it cannot be corrected without a release.
+ * The app row knows its own URL — ask it, and fall back to the old spelling only
+ * if the answer is missing.
+ */
 async function open(args) {
   const app = needApp(args);
-  const url = `https://${app}.supersonic.cv`;
+  const d = await api(`/api/apps/${app}`);
+  const url = d.url || `https://${app}.supersonic.cv`;
   info(`opening ${url}`);
   openBrowser(url);
 }
@@ -459,7 +845,7 @@ async function init(args) {
   // config is the ONE input the platform is required to obey, and replacing it
   // with a detector's guess would be this command undoing its own reason to exist.
   if (fs.existsSync(target) && !args.force) {
-    return die(`${r.CONFIG_FILENAME} already exists — read it, or \`supersonic init --force\` to overwrite it with a fresh draft`);
+    return die(`${r.CONFIG_FILENAME} already exists — read it, or \`bay init --force\` to overwrite it with a fresh draft`);
   }
 
   const { config, candidates } = await buildDraft(dir, { resolver: r, detect: detector() });
@@ -483,7 +869,7 @@ async function init(args) {
   const { problems } = await checkApp(dir, { resolver: r, detect: detector() });
   if (problems.length) {
     print("");
-    print(yellow("! ") + "and `supersonic check` would already fail on it:");
+    print(yellow("! ") + "and `bay check` would already fail on it:");
     for (const p of problems) print("  " + p);
   }
 }
@@ -580,13 +966,13 @@ async function deploy(args) {
   if (unknown.length) {
     die(
       `${unknown.map((f) => "--" + f).join(", ")} ${unknown.length > 1 ? "are not flags" : "is not a flag"} ` +
-      `supersonic ship understands.\n` +
+      `bay ship understands.\n` +
       `  It takes: ${SHIP_FLAGS.map((f) => "--" + f).join(", ")}\n` +
       "  Nothing was shipped. Fix the flag and run it again."
     );
   }
   // One command: sign in automatically the first time, then deploy. No separate
-  // `supersonic login` step required.
+  // `bay login` step required.
   await ensureAuth();
   // URL-first by default: a live link appears in ~0.1s — the address answers with
   // the room, which draws the build as it happens — while the real build runs on
@@ -596,7 +982,7 @@ async function deploy(args) {
   if (args.github || args.repo) {
     let repo = args.repo;
     if (!repo) { repo = await gitOrigin(); if (!repo) die("no git remote 'origin' found here — pass --repo <url>"); }
-    info(cyan("▸ ") + "deploying from " + bold(repo));
+    info(cyan("▸ ") + "shipping from " + bold(repo));
     const res = await api("/api/deploy", { method: "POST", body: { repo }, stream: true });
     return consumeDeploy(res, args);
   }
@@ -617,7 +1003,7 @@ async function deploy(args) {
   try { fs.unlinkSync(tgz); } catch { /* ignore */ }
   info(dim(`uploading ${(body.length / 1048576).toFixed(1)} MB`));
   const tok = token();
-  if (!tok) die("not authenticated — run: supersonic login");
+  if (!tok) die("not authenticated — run: bay login");
   const res = await fetch(baseUrl() + "/api/deploy", {
     method: "POST",
     headers: {
@@ -629,7 +1015,7 @@ async function deploy(args) {
     },
     body,
   });
-  if (res.status === 401) die("token invalid or expired — run: supersonic login");
+  if (res.status === 401) die("token invalid or expired — run: bay login");
   if (res.status === 403) die("forbidden");
   if (!res.body) die("no response stream");
   return consumeDeploy(res, args);
@@ -661,14 +1047,14 @@ async function urlFirstDeploy(args) {
   // checkmark as "done", stopped watching, and reported a working deploy for an
   // app that never came up. The URL is real and does work from here (it serves a
   // build page), so it stays; what leaves is the claim that the app is on it.
-  print(dim("⧗ ") + "deploying — your app will be live at " + bold(url));
+  print(dim("⧗ ") + "shipping — your app will be live at " + bold(url));
 
   // Default: DON'T hold the caller hostage for the whole build. A coding agent
-  // that runs `supersonic deploy` should get the live URL and its prompt back in
+  // that runs `bay deploy` should get the live URL and its prompt back in
   // ~1s, not sit blocked for two minutes. So the build is handed to a detached
   // background worker that keeps the deploy connection open (the server keeps
   // building, CPU allocated, until it lands) and logs to
-  // ~/.supersonic/deploys/<slug>.log. Pass --wait to stay attached and stream the
+  // <config dir>/deploys/<slug>.log. Pass --wait to stay attached and stream the
   // build here instead.
   if (!args.wait) {
     const logDir = path.join(CFG_DIR, "deploys");
@@ -699,7 +1085,7 @@ async function urlFirstDeploy(args) {
       const candidates = Object.keys(selectEnv(readEnvFiles(process.cwd())).send);
       if (candidates.length) print(dim("  carrying from .env: ") + candidates.join(", ") + dim(" (vars already set on the app are left alone)"));
     }
-    print(dim("  build finishing in the background · watch: ") + bold(`supersonic logs ${slug} --follow`));
+    print(dim("  build finishing in the background · watch: ") + bold(`bay logs ${slug} --follow`));
     process.exit(0);
   }
 
@@ -767,7 +1153,7 @@ async function runBuildAndWait({ slug, url, repo, folderName, args }) {
   // The log file used to be written only by the detached worker, because that is
   // where its stdout was redirected — so `--wait`, the mode where you are watching
   // and most likely to lose the terminal, was the one mode that kept no record.
-  // `supersonic logs` then reads from the server and shows the RUNNING app's logs,
+  // `bay logs` then reads from the server and shows the RUNNING app's logs,
   // which for a failed deploy is nothing at all.
   startDeployLog(slug);
 
@@ -807,7 +1193,7 @@ async function runBuildAndWait({ slug, url, repo, folderName, args }) {
     // would surface later as an app that is broken for no visible reason.
     const envHeader = encodeEnvHeader(envVars);
     if (envHeader) headers["x-supersonic-env"] = envHeader;
-    else if (envKeys.length) info(red("! ") + ".env is too large to send with the build — set them after it lands: " + bold(`supersonic env ${slug} set KEY=VALUE`));
+    else if (envKeys.length) info(red("! ") + ".env is too large to send with the build — set them after it lands: " + bold(`bay env ${slug} set KEY=VALUE`));
 
     // The bytes go to the bucket, not through the API. Attempted for every size
     // rather than only over the cap, so the path a large project depends on is
@@ -827,7 +1213,7 @@ async function runBuildAndWait({ slug, url, repo, folderName, args }) {
     } else {
       res = await fetch(baseUrl() + "/api/deploy", { method: "POST", headers, body });
     }
-    if (res.status === 401) { cleanup(); die("token invalid or expired — run: supersonic login"); }
+    if (res.status === 401) { cleanup(); die("token invalid or expired — run: bay login"); }
   }
   await consumeDeploy(res, args, slug);   // when the build goes live the proxy serves it on `url`
   print(green("✓ ") + "build is live at " + bold(url));
@@ -838,7 +1224,7 @@ async function runBuildAndWait({ slug, url, repo, folderName, args }) {
  * build after the foreground command has already returned the live URL. */
 async function deployWorker() {
   const slug = process.env.SS_BG_SLUG, url = process.env.SS_BG_URL;
-  if (!slug || !url) die("deploy worker: missing context");
+  if (!slug || !url) die("ship worker: missing context");
   await runBuildAndWait({
     slug, url,
     repo: process.env.SS_BG_REPO || "",
@@ -915,7 +1301,7 @@ async function tryPrebuilt(appName, args) {
   info(dim(`uploading ${(body.length / 1048576).toFixed(1)} MB of built output`));
 
   const tok = token();
-  if (!tok) die("not authenticated — run: supersonic login");
+  if (!tok) die("not authenticated — run: bay login");
   const res = await fetch(baseUrl() + "/api/deploy", {
     method: "POST",
     headers: {
@@ -929,7 +1315,7 @@ async function tryPrebuilt(appName, args) {
     },
     body,
   });
-  if (res.status === 401) die("token invalid or expired — run: supersonic login");
+  if (res.status === 401) die("token invalid or expired — run: bay login");
   if (res.status === 403) die("forbidden");
   if (!res.body) die("no response stream");
   return consumeDeploy(res, args);
@@ -962,8 +1348,8 @@ function packageDir(dir) {
 async function redeploy(args) {
   const app = needApp(args);
   const d = await api(`/api/apps/${app}`);
-  if (!d.repo) die(`${app} was deployed from a computer — run \`supersonic deploy\` in its folder to ship an update`);
-  info(cyan("▸ ") + "redeploying " + bold(app));
+  if (!d.repo) die(`${app} was shipped from a computer — run \`bay ship\` in its folder to send an update`);
+  info(cyan("▸ ") + "reshipping " + bold(app));
   // The slug travels, because the server would otherwise resolve one from the
   // repo URL — and an app created under a name of its own (the dashboard asks
   // for one) does not answer to that name, so the redeploy would build a
@@ -1011,6 +1397,10 @@ const BODY_LIMIT = 32 * 1024 * 1024;
 function encryptSource(buf, pass) {
   const { createCipheriv, scryptSync } = require("node:crypto");
   const iv = require("node:crypto").randomBytes(16);
+  // The salt is NOT renamed, and must not be. It is half of a key the control
+  // plane derives with the same literal (apps/web/lib/deploy-runs.ts, KEY_SALT):
+  // change it here and every upload decrypts to garbage on a server that still
+  // says the old word.
   const cipher = createCipheriv("aes-256-cbc", scryptSync(pass, "supersonic-deploy-run", 32), iv);
   return Buffer.concat([iv, cipher.update(buf), cipher.final()]);
 }
@@ -1029,7 +1419,7 @@ async function uploadSourceToBucket(body) {
       method: "POST",
       headers: { Authorization: "Bearer " + token(), "Content-Type": "application/json" },
     });
-    if (r.status === 401) die("token invalid or expired — run: supersonic login");
+    if (r.status === 401) die("token invalid or expired — run: bay login");
     if (!r.ok) return null;
     spot = await r.json();
   } catch { return null; }
@@ -1042,7 +1432,7 @@ async function uploadSourceToBucket(body) {
     headers: { "Content-Type": "application/octet-stream" },
     body: sealed,
   });
-  if (!put.ok) die(`upload failed (${put.status}) — the code never left your machine, so nothing was deployed`);
+  if (!put.ok) die(`upload failed (${put.status}) — the code never left your machine, so nothing was shipped`);
   return { object: spot.object, key };
 }
 
@@ -1129,7 +1519,7 @@ async function consumeDeploy(res, args, knownSlug) {
   }
   // The server can answer with a plain JSON error instead of a stream — a plan limit,
   // a rejected request. That is not a build that timed out, and saying so sent someone
-  // to `supersonic logs` looking for a failure that never happened. If what arrived
+  // to `bay logs` looking for a failure that never happened. If what arrived
   // parses as an error object, report what it actually said.
   const trailing = (buf || "").trim();
   if (trailing) {
@@ -1159,7 +1549,7 @@ async function consumeDeploy(res, args, knownSlug) {
     // Still building when we ran out of patience. Say that, rather than calling a
     // deploy failed that may be minutes from landing.
     if (args.json) json({ ok: false, slug, error: "still building — connection lost", pending: true, runId });
-    die(`lost contact with the build and it was still running after 3 minutes. It may still land — check: supersonic logs ${slug}`);
+    die(`lost contact with the build and it was still running after 3 minutes. It may still land — check: bay logs ${slug}`);
   }
 
   // No slug to ask about — the stream died before it named one, so there is
@@ -1167,11 +1557,11 @@ async function consumeDeploy(res, args, knownSlug) {
   // here: it is all the information there is.
   const lost = streamError ? ` (the connection failed: ${streamError})` : "";
   if (args.json) json({ ok: false, error: "deploy stream ended without a result", streamError });
-  die(`the deploy ended without confirming it went live${lost} — the build may have failed or timed out. Check: supersonic apps  ·  supersonic logs <app>`);
+  die(`the ship ended without confirming it went live${lost} — the build may have failed or timed out. Check: bay apps  ·  bay logs <app>`);
 }
 
 // ---------- helpers ----------
-function needApp(args) { const a = args._[0]; if (!a) die("missing app name — usage: supersonic " + args._cmd + " <app>"); return a; }
+function needApp(args) { const a = args._[0]; if (!a) die("missing app name — usage: bay " + args._cmd + " <app>"); return a; }
 function gitOrigin() {
   return new Promise((resolve) => {
     const p = spawn("git", ["remote", "get-url", "origin"], { stdio: ["ignore", "pipe", "ignore"] });
@@ -1183,69 +1573,101 @@ function gitOrigin() {
 
 function usage(all = false) {
   if (!all) {
-    print(`${bold("supersonic")} — publish your app in one command
+    print(`${bold("bay")} — publish your app in one command
 
 ${bold("just run this in your project folder:")}
-  ${green("supersonic ship")}            publish this folder and print the live URL
-                             (opens a browser to sign in the first time;
-                              ${dim("`deploy` is the same command")})
+  ${green("bay ship")}              publish this folder and print the live URL
+                        (opens a browser to sign in the first time;
+                         ${dim("`bay deploy` is the same command")})
 
 ${bold("before you ship")} ${dim("(local, ~2s, no cloud)")}
-  supersonic init            write a draft supersonic.json from this repo
-  supersonic check           what each phase would run, and what would fail
+  bay init              write a draft supersonic.json from this repo
+  bay check             what each phase would run, and what would fail
 
 ${bold("when something's wrong")}
-  supersonic logs <app>      recent logs
-  supersonic diagnose <app>  AI fix-prompt for your coding agent
-  supersonic apps            list your apps
-  supersonic open <app>      open the app in a browser
-  supersonic login           sign in manually
+  bay logs <app>        recent logs
+  bay diagnose <app>    AI fix-prompt for your coding agent
+  bay apps              list your apps
+  bay open <app>        open the app in a browser
+  bay login             sign in manually
 
-${dim("more commands: supersonic help --all  ·  --json on any command for machine output")}`);
+${bold("the rest of the platform")} ${dim("(nothing here needs the dashboard)")}
+  bay share <app> public          who can open it
+  bay domains <app> add <host>    connect a domain you own
+  bay db <app>                    read its database
+
+${dim("more commands: bay help --all  ·  --json on any command for machine output")}`);
     return;
   }
-  print(`${bold("supersonic")} — deploy & debug from your coding agent
+  print(`${bold("bay")} — ship & debug from your coding agent
 
 ${bold("setup")}
-  supersonic signup                            create an account (opens browser, one time)
-  supersonic login [--url <u>] [--token <t>]   authenticate (browser, one time)
-  supersonic logout
-  supersonic whoami
+  bay signup                            create an account (opens browser, one time)
+  bay login [--url <u>] [--token <t>]   authenticate (browser, one time)
+  bay logout
+  bay whoami
 
 ${bold("author")} ${dim("(local: no cloud, no build, no model — about two seconds)")}
-  supersonic init [dir] [--force]               write a DRAFT supersonic.json for an agent to correct
-  supersonic check [dir]                        resolve + validate it, and print what each phase would run
+  bay init [dir] [--force]               write a DRAFT supersonic.json for an agent to correct
+  bay check [dir]                        resolve + validate it, and print what each phase would run
 
 ${bold("ship")} ${dim("(URL-first: a live link in ~0.1s, the build drawn on it while it runs)")}
-  supersonic ship                               ship this folder — live URL now, build behind it
-  supersonic ship --name <name>                 what to call it (default: this folder's name)
-  ${dim("(`deploy` does the same thing and always will — every flag below works with either)")}
-  supersonic ship --run "<prod start cmd>"    how to run it in PROD — you know the stack
-                                                  e.g. --run "uvicorn main:app --host 0.0.0.0 --port $PORT"
-  supersonic ship --wait                      stay attached and stream the build (default: returns once live)
-  supersonic ship --no-env                    don't carry .env up (default: sets vars your app doesn't have yet)
-  supersonic ship --github [--repo <url>]     deploy from GitHub / a git URL instead
-  supersonic ship --prebuilt                  old path: build here, upload the result
-  supersonic reship <app>                       rebuild from the app's source
-  supersonic patch <app>                        the repair agent's fix, to pipe into git apply
-  supersonic rollback <app>                     roll back to the previous version
-  supersonic delete <app> --yes                 delete an app (its database and bucket are kept)
+  bay ship                               ship this folder — live URL now, build behind it
+  bay ship --name <name>                 what to call it (default: this folder's name)
+  ${dim("(`bay deploy` does the same thing and always will — every flag here works with either)")}
+  bay ship --run "<prod start cmd>"      how to run it in PROD — you know the stack
+                                         e.g. --run "uvicorn main:app --host 0.0.0.0 --port $PORT"
+  bay ship --wait                        stay attached and stream the build (default: returns once live)
+  bay ship --no-env                      don't carry .env up (default: sets vars your app doesn't have yet)
+  bay ship --github [--repo <url>]       ship from GitHub / a git URL instead
+  bay ship --prebuilt                    old path: build here, upload the result
+  bay reship <app>                       rebuild from the app's source
+  bay patch <app>                        the repair agent's fix, to pipe into git apply
+  bay rollback <app>                     roll back to the previous version
+  bay delete <app> --yes                 delete an app (its database and bucket are kept)
 
 ${bold("inspect")}
-  supersonic apps                               list your apps
-  supersonic status <app>                       revision, url, env, database
-  supersonic logs <app> [--severity error] [--limit 50] [--since 1h] [--follow]
-  supersonic errors <app>                       production errors (7d)
-  supersonic diagnose <app> [--error "..."]     AI fix-prompt for your agent
-  supersonic exec <app> -- <command>            run a command in the app's env (isolated)
+  bay apps                               list your apps
+  bay status <app>                       revision, url, env, database
+  bay logs <app> [--severity error] [--limit 50] [--since 1h] [--follow]
+  bay errors <app>                       production errors (7d)
+  bay diagnose <app> [--error "..."]     AI fix-prompt for your agent
+  bay exec <app> -- <command>            run a command in the app's env (isolated)
 
 ${bold("config")}
-  supersonic env <app>                          list env var keys
-  supersonic env <app> set KEY=VALUE            set env var(s)
-  supersonic env <app> unset KEY                remove env var(s)
-  supersonic open <app>                         open the app in a browser
+  bay env <app>                          list env var keys
+  bay env <app> set KEY=VALUE            set env var(s)
+  bay env <app> unset KEY                remove env var(s)
+  bay open <app>                         open the app in a browser
 
-${dim("global: --json for machine-readable output · $SUPERSONIC_TOKEN overrides login")}`);
+${bold("who can open it")}
+  bay share <app>                        the visibility, the people, the rules, who is asking
+  bay share <app> private|shared|public  change it
+  bay share <app> add ada@acme.com       invite one person (they get an email)
+  bay share <app> add @acme.com          everyone with an address there
+  bay share <app> remove <email|@domain>
+
+${bold("its own address")}
+  bay domains <app>                      what is attached, and the DNS record to create
+  bay domains <app> add acme.com         attach a domain you own
+  bay domains <app> remove acme.com
+
+${bold("its data")}
+  bay db <app>                           the tables, with row counts
+  bay db <app> <table> [--limit 50] [--offset 0]
+  bay db <app> --sql "select ..."        one read-only statement
+
+${bold("shipping from GitHub")}
+  bay git <app>                          the repo it follows, and whether a push ships
+  bay git <app> --branch main --auto on
+  bay git <app> disconnect
+
+${bold("the account")}
+  bay plan                               plan, every limit, and what is left of it
+  bay tokens                             every CLI signed in to this account
+  bay tokens revoke <id>                 take one back
+
+${dim("global: --json for machine-readable output · $BAY_TOKEN overrides login")}`);
 }
 
 // ---------- arg parsing ----------
@@ -1273,7 +1695,7 @@ function parse(argv) {
  * prompt, README and script that already exists, so it does not get deprecated,
  * warned about, or removed. Two words, one command, forever.
  */
-const COMMANDS = { signup, login, logout, whoami, apps, status, logs, errors, diagnose, env, patch, rollback, exec, open, init, check, ship: deploy, deploy, reship: redeploy, redeploy, delete: del, rm: del, "__deploy-worker": deployWorker };
+const COMMANDS = { signup, login, logout, whoami, apps, status, logs, errors, diagnose, env, domains, domain: domains, share, access: share, db, git, plan, account: plan, tokens, patch, rollback, exec, open, init, check, ship: deploy, deploy, reship: redeploy, redeploy, delete: del, rm: del, "__deploy-worker": deployWorker };
 
 (async () => {
   const [, , cmd, ...rest] = process.argv;

--- a/packages/cli/lib/check.js
+++ b/packages/cli/lib/check.js
@@ -143,7 +143,7 @@ async function checkApp(dir, { resolver: r, detect }) {
 function secretWarnings(r, app, available) {
   const missing = r.missingSecrets(app, available);
   if (!missing.length) return [];
-  return [`${missing.join(", ")} ${missing.length === 1 ? "is" : "are"} declared under \`secrets\` and set nowhere here — supersonic env <app> set, or a .env`];
+  return [`${missing.join(", ")} ${missing.length === 1 ? "is" : "are"} declared under \`secrets\` and set nowhere here — bay env <app> set, or a .env`];
 }
 
 const PHASE_WIDTH = 10;
@@ -203,7 +203,20 @@ function renderService(s) {
     // has no start command, no health path and no request timeout, and printing
     // the defaults for all three would describe a service that is not deployed.
     if (!s.serviceless) {
-      lines.push(phase("start", s.lane === "container"
+      // Keyed off the AUTHOR's Dockerfile, not off the lane.
+      //
+      // Asking `s.lane === "container"` was right while there were four lanes.
+      // There are two. `container` now means "an image is built and a node runs
+      // it" whether the author committed a Dockerfile or `generateDockerfile`
+      // wrote one FROM THIS `start` COMMAND — so the old condition answered "the
+      // Dockerfile's own CMD" for every non-static service, about a repository
+      // with no Dockerfile in it, hiding a command the config states in plain
+      // text. In the one command whose whole job is to say what will run.
+      //
+      // `s.dockerfile` is the author's file and only ever that; resolve.ts draws
+      // the same line. The `image` phase above already names it, so this line
+      // does not repeat the path.
+      lines.push(phase("start", s.dockerfile
         ? "the Dockerfile's own CMD"
         : s.start || (s.runs.length ? "—  (the web process below)" : "—  (nothing to run: this lane needs one)")));
       // The web process's own health check is what the deploy probes, so it is
@@ -255,7 +268,7 @@ function renderCheck(configFilename, app, problems, warnings) {
     // file that is not there.
     const from = app.source === "config"
       ? configFilename
-      : `inferred — there is no ${configFilename} (\`supersonic init\` writes one)`;
+      : `inferred — there is no ${configFilename} (\`bay init\` writes one)`;
     const yours = external ? `, uses your own ${external.engine || "database"} from ${external.urlFrom}` : "";
     lines.push(`${from} — ${n} service${n === 1 ? "" : "s"}${provisioned.length ? `, provisions ${provisioned.join(" + ")}` : ""}${yours}`);
     lines.push("");
@@ -271,7 +284,7 @@ function renderCheck(configFilename, app, problems, warnings) {
       lines.push(head.startsWith("✕") ? head : `✕ ${head}`, ...rest);
     }
     lines.push("");
-    lines.push(`${problems.length} problem${problems.length === 1 ? "" : "s"} — nothing was deployed, and nothing would be.`);
+    lines.push(`${problems.length} problem${problems.length === 1 ? "" : "s"} — nothing was shipped, and nothing would be.`);
   } else {
     lines.push("✓ nothing here fails before the build. No GCP was touched.");
   }

--- a/packages/cli/lib/confirm.js
+++ b/packages/cli/lib/confirm.js
@@ -27,19 +27,19 @@ function deletionRefusal(app, args) {
   if (said === true || (typeof said === "string" && said === app)) return null;
 
   // A DIFFERENT app name is refused rather than ignored, and this is the case
-  // worth having a branch for: `supersonic delete api --yes web` is somebody
+  // worth having a branch for: `bay delete api --yes web` is somebody
   // editing a previous command and changing one of the two names. Proceeding
   // would delete `api` on the strength of a confirmation that says `web`.
   if (typeof said === "string" && said !== app) {
-    return `refusing: you named ${app} but confirmed ${said}. If you mean ${app}, run\n  supersonic delete ${app} --yes`;
+    return `refusing: you named ${app} but confirmed ${said}. If you mean ${app}, run\n  bay delete ${app} --yes`;
   }
 
   return [
     `${app} would be deleted, and so would its DATA: the database, the storage`,
-    "bucket, the images and the deploy history all go with it.",
+    "bucket, the images and the ship history all go with it.",
     "",
     "This cannot be undone, and there is no prompt to say yes to — run",
-    `  supersonic delete ${app} --yes`,
+    `  bay delete ${app} --yes`,
   ].join("\n");
 }
 

--- a/packages/cli/lib/draft.js
+++ b/packages/cli/lib/draft.js
@@ -478,7 +478,7 @@ function renderDraft(configFilename, config, unknowns) {
   // confidence answer. Presenting its output as a finding rather than a draft is
   // how that answer became a deploy.
   lines.push("This is a draft, from a detector that has been confidently wrong before.");
-  lines.push(`Read it, fix what is wrong, then: supersonic check`);
+  lines.push(`Read it, fix what is wrong, then: bay check`);
   return lines;
 }
 

--- a/packages/cli/lib/exec-args.js
+++ b/packages/cli/lib/exec-args.js
@@ -5,9 +5,9 @@
  *
  * Two shapes reach this, and joining them the same way breaks one of them:
  *
- *   supersonic exec app -- "ls | wc -l"           one argument, already a shell
+ *   bay exec app -- "ls | wc -l"           one argument, already a shell
  *                                                 snippet — the pipe is meant
- *   supersonic exec app -- python -c 'print(1)'   argv, and the local shell has
+ *   bay exec app -- python -c 'print(1)'   argv, and the local shell has
  *                                                 already removed the quotes
  *
  * A plain `.join(" ")` served the first and silently corrupted the second. The

--- a/packages/cli/lib/home.js
+++ b/packages/cli/lib/home.js
@@ -1,0 +1,46 @@
+"use strict";
+
+/**
+ * Where the session lives, and what the variables are called, across a rename.
+ *
+ * Both answers changed at once — `~/.supersonic` became `~/.bay`, `SUPERSONIC_*`
+ * became `BAY_*` — and both have the same failure mode if they change carelessly:
+ * the CLI comes up signed out. Not broken, not erroring; signed out, with a
+ * perfectly good token sitting in a file it stopped looking at, and an agent
+ * mid-task being told to open a browser.
+ *
+ * Pure, and taking the home directory and an existence check as arguments, so
+ * the migration can be tested without touching anyone's real home.
+ */
+
+/**
+ * The config directory: the new name if it is there, the old name if IT is, the
+ * new name otherwise.
+ *
+ * Deliberately not "read both and merge". Two files that disagree about which
+ * account you are would be resolved by whichever line ran first, and the symptom
+ * — deploying to the wrong account — is one nobody would trace back to here. One
+ * directory wins outright, and an existing user keeps writing to the file they
+ * already have.
+ */
+function configDirIn(home, exists, join) {
+  const next = join(home, ".bay");
+  const prev = join(home, ".supersonic");
+  if (exists(next)) return next;
+  if (exists(prev)) return prev;
+  return next;
+}
+
+/**
+ * `BAY_<NAME>`, falling back to `SUPERSONIC_<NAME>`.
+ *
+ * The new name wins when both are set: somebody who exported both is midway
+ * through a migration, and the value they added last is the one they mean. An
+ * empty string is treated as unset, which is what a shell gives you for an
+ * exported-but-never-assigned variable.
+ */
+function envVarFrom(env, name) {
+  return (env["BAY_" + name] || env["SUPERSONIC_" + name] || "").trim();
+}
+
+module.exports = { configDirIn, envVarFrom };

--- a/packages/cli/lib/resolver.js
+++ b/packages/cli/lib/resolver.js
@@ -11,8 +11,8 @@
  *
  * Loaded lazily and through a named function rather than at require() time: the
  * bundle is generated, an old global install can be missing it, and a missing
- * bundle must fail `supersonic check` with a sentence naming the fix rather than
- * crashing `supersonic logs`, which does not use it at all.
+ * bundle must fail `bay check` with a sentence naming the fix rather than
+ * crashing `bay logs`, which does not use it at all.
  */
 const path = require("node:path");
 

--- a/packages/cli/lib/rows.js
+++ b/packages/cli/lib/rows.js
@@ -1,0 +1,61 @@
+"use strict";
+
+/**
+ * Query results as a table a terminal can hold.
+ *
+ * `bay db <app> <table>` returns real production rows, and a row is not a
+ * shape this CLI controls: one column is an id, the next is a 4KB blob of JSON,
+ * and printing them raw turns a 12-row answer into four screens of wrapped text
+ * with no visible columns at all. So every cell is flattened to one line and
+ * clipped, and the width is the widest cell that survived.
+ *
+ * Clipping is marked with `…` rather than being silent. A truncated value that
+ * looks whole is worse than no value: it is the one a person copies.
+ *
+ * `--json` exists for everything this drops. That is the contract — this is the
+ * human reading, `--json` is the data.
+ */
+
+/** null and undefined are not the string "null" — they are the empty cell. */
+function cell(v, max) {
+  if (v === null || v === undefined) return "";
+  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  // Tabs and newlines inside a value would break the alignment of every row
+  // after them, so they become a single space before anything is measured.
+  const flat = s.replace(/\s+/g, " ").trim();
+  return flat.length > max ? flat.slice(0, max - 1) + "…" : flat;
+}
+
+/**
+ * @param {string[]} columns
+ * @param {object[]} rows
+ * @param {{max?: number}} [opts]  max characters per cell (default 40)
+ * @returns {string[]} lines: a header, a rule, then one line per row
+ */
+function renderTable(columns, rows, opts = {}) {
+  const max = opts.max ?? 40;
+  const cols = columns || [];
+  if (!cols.length) return [];
+
+  const body = (rows || []).map((r) =>
+    // Arrays as well as objects: `SELECT` results arrive keyed by column name,
+    // but a caller holding tuples should not have to convert them first.
+    cols.map((c, i) => cell(Array.isArray(r) ? r[i] : r?.[c], max))
+  );
+
+  const width = cols.map((c, i) =>
+    Math.max(cell(c, max).length, ...body.map((r) => r[i].length), 1)
+  );
+
+  // The last column is not padded. Trailing spaces are invisible until somebody
+  // pipes this into a diff, and every line would carry them.
+  const line = (parts) => parts.map((p, i) => (i === parts.length - 1 ? p : p.padEnd(width[i]))).join("  ").trimEnd();
+
+  return [
+    line(cols.map((c) => cell(c, max))),
+    line(width.map((w) => "─".repeat(w))),
+    ...body.map(line),
+  ];
+}
+
+module.exports = { renderTable, cell };

--- a/packages/cli/lib/share-args.js
+++ b/packages/cli/lib/share-args.js
@@ -1,0 +1,93 @@
+"use strict";
+
+/**
+ * What `bay share` was asked to do, decided before anything is sent.
+ *
+ * Access is the one command in this CLI where a misread argument does damage
+ * that is not visible afterwards: `share app add luwo.ai` meant as "everyone at
+ * my company" and read as an email address would fail loudly, which is fine —
+ * but read the other way round it would let a whole domain into an app the
+ * owner meant to send to one person, and nothing on screen would look wrong.
+ * So the reading is a pure function with tests, and the network call is what
+ * happens after it.
+ *
+ * The two audiences are told apart by shape, not by a flag:
+ *
+ *   ada@acme.com   an address        -> one person, invited by email
+ *   @acme.com      a rule            -> everyone whose address ends in it
+ *   acme.com       the same rule     -> the @ is how people write it, not a requirement
+ *
+ * A bare word with no dot is neither, and is refused rather than guessed at.
+ */
+
+/** The three visibilities the control plane accepts, in the order they widen. */
+const VISIBILITIES = ["private", "shared", "public"];
+
+/**
+ * @param {string} who
+ * @returns {{audience: "email"|"domain", value: string}|null}
+ */
+function audienceOf(who) {
+  const w = String(who ?? "").trim().toLowerCase();
+  if (!w) return null;
+
+  // An @ anywhere but the front makes it an address. RFC 5321 caps a mailbox at
+  // 254 characters; past that it is not an address that could ever be delivered
+  // to, and the server refuses it — better said here, where the reason fits on
+  // one line.
+  if (w.includes("@") && !w.startsWith("@")) {
+    if (w.length > 254 || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(w)) return null;
+    return { audience: "email", value: w };
+  }
+
+  const domain = w.replace(/^@/, "");
+  if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/.test(domain)) return null;
+  return { audience: "domain", value: domain };
+}
+
+/**
+ * @param {string[]} rest  the arguments after the app name
+ * @returns {{kind: "show"}
+ *          |{kind: "visibility", visibility: string}
+ *          |{kind: "add"|"remove", audience: "email"|"domain", value: string}
+ *          |{kind: "error", why: string}}
+ */
+function parseShare(rest) {
+  const [verb, ...targets] = (rest || []).filter((t) => t !== undefined && t !== null);
+  if (!verb) return { kind: "show" };
+
+  const v = String(verb).trim().toLowerCase();
+  if (VISIBILITIES.includes(v)) return { kind: "visibility", visibility: v };
+
+  if (v === "add" || v === "remove" || v === "rm") {
+    const kind = v === "rm" ? "remove" : v;
+    if (!targets.length) {
+      return { kind: "error", why: `who? usage: bay share <app> ${kind} <email|@domain>` };
+    }
+    const audience = audienceOf(targets[0]);
+    if (!audience) {
+      return {
+        kind: "error",
+        why: `"${targets[0]}" is neither an email address nor a domain — write ada@acme.com for one person, or @acme.com for everyone there`,
+      };
+    }
+    return { kind, ...audience };
+  }
+
+  return {
+    kind: "error",
+    why: `unknown: share ${v}\nusage: bay share <app> [private|shared|public | add <email|@domain> | remove <email|@domain>]`,
+  };
+}
+
+/**
+ * The request body for an add/remove, in the shape the control plane's share
+ * route reads. Kept beside the parser because the four field names — addEmail,
+ * addDomain, removeEmail, removeDomain — are the only thing connecting the two.
+ */
+function shareBody(action) {
+  const suffix = action.audience === "email" ? "Email" : "Domain";
+  return { [action.kind + suffix]: action.value };
+}
+
+module.exports = { parseShare, audienceOf, shareBody, VISIBILITIES };

--- a/packages/cli/lib/who.js
+++ b/packages/cli/lib/who.js
@@ -2,12 +2,13 @@
 /**
  * Who is shipping, as declared — never as inferred.
  *
- * An agent sets SUPERSONIC_WHO=agent. Nothing else is consulted: a TTY check
- * would call CI an agent, and the platform would then draw a figure that was
- * never there. The absence of a name is a fact; a wrong name is a lie.
+ * An agent sets BAY_WHO=agent (SUPERSONIC_WHO is still read, because it is what
+ * the agent prompts written before the rename say). Nothing else is consulted: a
+ * TTY check would call CI an agent, and the platform would then draw a figure
+ * that was never there. The absence of a name is a fact; a wrong name is a lie.
  */
 function whoHeader(env) {
-  const v = String(env.SUPERSONIC_WHO || "").trim().toLowerCase();
+  const v = String(env.BAY_WHO || env.SUPERSONIC_WHO || "").trim().toLowerCase();
   return v === "you" || v === "agent" || v === "platform" ? v : "someone";
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "supersonic-cli",
+  "name": "bay-cli",
   "version": "0.12.1",
-  "description": "Deploy & debug Supersonic apps from your coding agent \u2014 the agent-native CLI.",
+  "description": "Ship & debug Bay apps from your coding agent \u2014 the agent-native CLI.",
   "bin": {
+    "bay": "./index.js",
     "supersonic": "./index.js"
   },
   "type": "commonjs",
@@ -29,9 +30,9 @@
     "gcp",
     "cloud-run",
     "vibecoding",
-    "supersonic"
+    "bay"
   ],
-  "homepage": "https://app.supersonic.cv",
+  "homepage": "https://thebay.cloud",
   "repository": {
     "type": "git",
     "url": "https://github.com/The-Red-Onion/supersonic",

--- a/packages/cli/test/check.test.js
+++ b/packages/cli/test/check.test.js
@@ -66,14 +66,20 @@ test("each phase is printed as it would actually run", async () => {
   assert.match(site, /publish {3}web\/dist {2}· {2}unknown paths → index\.html/);
   assert.doesNotMatch(site, /start|health/);
 
-  // The buildpack lane, not the runner: this service pins `python3.12` and the
-  // runner has one Python. It used to say "runner", which is how an app asking
-  // for 3.12 was given 3.14 — parsed, validated, printed back right here, and
-  // ignored. `check` says what the deploy will actually do.
-  assert.match(api, /buildpack lane {2}· {2}\/api/);
+  // The container lane — the only one that runs a service now, since buildpack
+  // and runner were removed. What is pinned is not the lane's NAME: it is that
+  // this service asks for `python3.12` and `check` says so, because an app asking
+  // for 3.12 was once given 3.14 — parsed, validated, printed back right here,
+  // and ignored.
+  assert.match(api, /container lane {2}· {2}\/api/);
   assert.match(api, /runtime {3}python3\.12/);
   assert.match(api, /release {3}\(cd srv && alembic upgrade head\)/);
+  // There is no Dockerfile in this repository, so the start command is the one
+  // the config states — not "the Dockerfile's own CMD", which is what this said
+  // for every service between the buildpack lane's removal and the fix in
+  // lib/check.js. A deploy generates a Dockerfile whose CMD is exactly this.
   assert.match(api, /start {5}\(cd srv && uvicorn main:app --port \$PORT\)/);
+  assert.doesNotMatch(api, /Dockerfile's own CMD/);
   assert.match(api, /health {4}GET \/ → 200/);
   assert.match(api, /uses {6}database/);
 });
@@ -189,8 +195,8 @@ test("the report names its source, and never claims a file that is not there", a
   assert.match(inferred, /inferred — there is no supersonic\.json/);
 });
 
-test("problems are counted, and the report says nothing was deployed", () => {
+test("problems are counted, and the report says nothing was shipped", () => {
   const text = renderCheck("supersonic.json", null, ["✕ one\n  detail", "✕ two"], []).join("\n");
   assert.match(text, /^ {2}detail$/m);
-  assert.match(text, /2 problems — nothing was deployed, and nothing would be\./);
+  assert.match(text, /2 problems — nothing was shipped, and nothing would be\./);
 });

--- a/packages/cli/test/confirm.test.js
+++ b/packages/cli/test/confirm.test.js
@@ -8,7 +8,7 @@ test("deleting without saying yes is refused, and the refusal is the command to 
   // first" without saying HOW is a message that gets guessed at.
   const out = deletionRefusal("myapp", {});
   assert.ok(out);
-  assert.match(out, /supersonic delete myapp --yes/);
+  assert.match(out, /bay delete myapp --yes/);
 });
 
 test("the refusal says the data goes too, because that is the part people get wrong", () => {

--- a/packages/cli/test/draft.test.js
+++ b/packages/cli/test/draft.test.js
@@ -1,6 +1,6 @@
 "use strict";
 /**
- * What `supersonic init` writes, against real directories on disk.
+ * What `bay init` writes, against real directories on disk.
  *
  * Real trees rather than stubbed detector answers, because the thing under test is
  * exactly "does this read a repository correctly" — and the case that motivated
@@ -292,5 +292,5 @@ test("the output says it is a draft, and says what it could not determine", asyn
   // The sentence that makes the whole thing safe: this is a detector that has been
   // confidently wrong, and its answer is now reviewable rather than invisible.
   assert.match(text, /This is a draft, from a detector that has been confidently wrong before\./);
-  assert.match(text, /supersonic check/);
+  assert.match(text, /bay check/);
 });

--- a/packages/cli/test/exec-args.test.js
+++ b/packages/cli/test/exec-args.test.js
@@ -7,7 +7,7 @@ const { joinExecArgs, shellQuote } = require("../lib/exec-args");
 
 test("an argv command keeps the quoting the local shell removed", () => {
   // The bug, verbatim. Typed as:
-  //   supersonic exec app -- python -c 'import os; print(os.environ["X"])'
+  //   bay exec app -- python -c 'import os; print(os.environ["X"])'
   // the local shell hands us three words with the quotes already gone, and a
   // plain join sent `print(os.environ[...])` to sh, which answered
   // `Syntax error: "(" unexpected`.

--- a/packages/cli/test/home.test.js
+++ b/packages/cli/test/home.test.js
@@ -1,0 +1,48 @@
+"use strict";
+/**
+ * The rename's one dangerous edge: a CLI that comes up signed out because it
+ * stopped looking where the token is.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { configDirIn, envVarFrom } = require("../lib/home");
+
+const dirs = (...present) => (p) => present.includes(p);
+
+test("an existing ~/.bay is used", () => {
+  assert.equal(configDirIn("/home/ada", dirs("/home/ada/.bay"), path.join), "/home/ada/.bay");
+});
+
+test("a user who only has the old directory stays signed in", () => {
+  assert.equal(configDirIn("/home/ada", dirs("/home/ada/.supersonic"), path.join), "/home/ada/.supersonic");
+});
+
+test("a fresh machine gets the new name, never the old one", () => {
+  assert.equal(configDirIn("/home/ada", dirs(), path.join), "/home/ada/.bay");
+});
+
+test("with both present the new one wins, and nothing is merged", () => {
+  assert.equal(
+    configDirIn("/home/ada", dirs("/home/ada/.bay", "/home/ada/.supersonic"), path.join),
+    "/home/ada/.bay",
+  );
+});
+
+test("the old variables still authenticate", () => {
+  assert.equal(envVarFrom({ SUPERSONIC_TOKEN: "ss_old" }, "TOKEN"), "ss_old");
+  assert.equal(envVarFrom({ BAY_TOKEN: "ss_new" }, "TOKEN"), "ss_new");
+});
+
+test("the new variable wins when both are exported", () => {
+  assert.equal(envVarFrom({ BAY_URL: "https://new", SUPERSONIC_URL: "https://old" }, "URL"), "https://new");
+});
+
+test("unset, empty and whitespace are all unset", () => {
+  assert.equal(envVarFrom({}, "TOKEN"), "");
+  assert.equal(envVarFrom({ BAY_TOKEN: "" }, "TOKEN"), "");
+  assert.equal(envVarFrom({ BAY_TOKEN: "  " }, "TOKEN"), "");
+  // An empty BAY_ must not shadow a real SUPERSONIC_ — that is the shape of an
+  // exported-but-never-assigned variable, and it would sign the user out.
+  assert.equal(envVarFrom({ BAY_TOKEN: "", SUPERSONIC_TOKEN: "ss_old" }, "TOKEN"), "ss_old");
+});

--- a/packages/cli/test/removed-flags.test.js
+++ b/packages/cli/test/removed-flags.test.js
@@ -48,6 +48,6 @@ test("a flag ship does not understand stops it, rather than being ignored", () =
 test("the flags ship does understand still work", () => {
   // The guard must not become the reason a real flag stops working.
   const { out } = deployWith("--help");
-  assert.match(out, /supersonic ship/);
+  assert.match(out, /bay ship/);
   assert.equal(/is not a flag/.test(out), false);
 });

--- a/packages/cli/test/rows.test.js
+++ b/packages/cli/test/rows.test.js
@@ -1,0 +1,60 @@
+"use strict";
+/**
+ * Production rows are not a shape this CLI controls, and the renderer's job is
+ * to stay readable when they are hostile: a JSON blob in one column, a newline
+ * inside a value, a null beside a number.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { renderTable, cell } = require("../lib/rows");
+
+test("columns line up under their headers", () => {
+  const out = renderTable(["id", "email"], [
+    { id: 1, email: "ada@acme.com" },
+    { id: 22, email: "b@c.io" },
+  ]);
+  assert.equal(out[0], "id  email");
+  // The rule spans the COLUMN, which is as wide as its widest cell — not as
+  // wide as the header word.
+  assert.equal(out[1], "──  " + "─".repeat("ada@acme.com".length));
+  assert.equal(out[2], "1   ada@acme.com");
+  assert.equal(out[3], "22  b@c.io");
+});
+
+test("null is an empty cell, not the word null", () => {
+  assert.equal(cell(null, 40), "");
+  assert.equal(cell(undefined, 40), "");
+  assert.equal(cell(0, 40), "0");
+  assert.equal(cell(false, 40), "false");
+});
+
+test("a newline inside a value cannot break the row below it", () => {
+  const out = renderTable(["note"], [{ note: "line one\nline two" }]);
+  assert.equal(out.length, 3);
+  assert.equal(out[2], "line one line two");
+});
+
+test("a long value is clipped, and says so", () => {
+  const out = renderTable(["blob"], [{ blob: "x".repeat(100) }], { max: 10 });
+  assert.equal(out[2], "x".repeat(9) + "…");
+});
+
+test("objects are JSON, not [object Object]", () => {
+  assert.equal(cell({ a: 1 }, 40), '{"a":1}');
+});
+
+test("no trailing whitespace on any line", () => {
+  for (const l of renderTable(["a", "bbbb"], [{ a: "xxxx", bbbb: "y" }])) {
+    assert.equal(l, l.trimEnd(), JSON.stringify(l));
+  }
+});
+
+test("tuples are accepted as well as keyed rows", () => {
+  const out = renderTable(["a", "b"], [[1, 2]]);
+  assert.equal(out[2], "1  2");
+});
+
+test("no columns is no output, not a crash", () => {
+  assert.deepEqual(renderTable([], [{ a: 1 }]), []);
+  assert.deepEqual(renderTable(undefined, undefined), []);
+});

--- a/packages/cli/test/share-args.test.js
+++ b/packages/cli/test/share-args.test.js
@@ -1,0 +1,57 @@
+"use strict";
+/**
+ * Reading a share argument, which is the one place in this CLI where the wrong
+ * reading is quiet.
+ *
+ * `share app add acme.com` means "everyone at acme.com". If that were read as an
+ * email address the server would refuse it and the user would see why. The
+ * dangerous direction is the other one — a person's address read as a company
+ * rule would open the app to a whole domain and print a success line, so the
+ * shape test is written down here rather than left to the server.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { parseShare, audienceOf, shareBody } = require("../lib/share-args");
+
+test("no verb is a question, not a change", () => {
+  assert.deepEqual(parseShare([]), { kind: "show" });
+  assert.deepEqual(parseShare(undefined), { kind: "show" });
+});
+
+test("the three visibilities are recognised, and nothing else is", () => {
+  for (const v of ["private", "shared", "public"]) {
+    assert.deepEqual(parseShare([v]), { kind: "visibility", visibility: v });
+  }
+  assert.deepEqual(parseShare(["PUBLIC"]), { kind: "visibility", visibility: "public" });
+  assert.equal(parseShare(["open"]).kind, "error");
+});
+
+test("an address is a person and a domain is a rule", () => {
+  assert.deepEqual(parseShare(["add", "ada@acme.com"]), { kind: "add", audience: "email", value: "ada@acme.com" });
+  assert.deepEqual(parseShare(["add", "@acme.com"]), { kind: "add", audience: "domain", value: "acme.com" });
+  // The @ is how people write a rule, not something the parser needs.
+  assert.deepEqual(parseShare(["add", "acme.com"]), { kind: "add", audience: "domain", value: "acme.com" });
+  assert.deepEqual(parseShare(["remove", "Ada@Acme.com"]), { kind: "remove", audience: "email", value: "ada@acme.com" });
+  assert.deepEqual(parseShare(["rm", "@acme.co.uk"]), { kind: "remove", audience: "domain", value: "acme.co.uk" });
+});
+
+test("a word that is neither is refused rather than guessed at", () => {
+  for (const bad of ["ada", "localhost", "@", "ada@", "@.com", "a b@c.com"]) {
+    assert.equal(parseShare(["add", bad]).kind, "error", `${bad} should not parse`);
+  }
+  // RFC 5321's 254-character mailbox limit, so an address that could never be
+  // delivered to is refused here rather than in a 400 from the server.
+  assert.equal(audienceOf("a".repeat(250) + "@acme.com"), null);
+});
+
+test("add and remove need a target", () => {
+  assert.equal(parseShare(["add"]).kind, "error");
+  assert.match(parseShare(["remove"]).why, /usage/);
+});
+
+test("the body names the field the share route reads", () => {
+  assert.deepEqual(shareBody({ kind: "add", audience: "email", value: "ada@acme.com" }), { addEmail: "ada@acme.com" });
+  assert.deepEqual(shareBody({ kind: "add", audience: "domain", value: "acme.com" }), { addDomain: "acme.com" });
+  assert.deepEqual(shareBody({ kind: "remove", audience: "email", value: "ada@acme.com" }), { removeEmail: "ada@acme.com" });
+  assert.deepEqual(shareBody({ kind: "remove", audience: "domain", value: "acme.com" }), { removeDomain: "acme.com" });
+});


### PR DESCRIPTION
A coding agent holding nothing but a shell can now find out what this platform is, and then operate all of it.

## The root answers a terminal with the manual

`curl thebay.cloud` printed 38KB of markup. It now serves `/llms.txt` when the client is not a browser — anything claiming `text/html` still gets the landing page, including every link-preview crawler, which sends a wildcard `Accept` and exists to read the og: tags. A rewrite, not a redirect: curl does not follow one unless told to, so a 307 would print a Location header and nothing else.

Verified against ten clients (curl, wget, httpie, python-requests, node, bun, deno, Slackbot, facebookexternalhit, Googlebot). The manual also answers at `/agents.md`, `/AGENTS.md`, `/agents.txt` and `/cli.md`, because names are guesses and a guess that 404s costs an agent a turn.

## Everything the dashboard does, the CLI does

| | |
|---|---|
| `bay share` | visibility, people, `@company` rules, who is waiting |
| `bay domains` | attach a domain, and the one DNS record to create |
| `bay db` | tables, a page of rows, one read-only SELECT |
| `bay git` | which branch it follows, whether a push ships |
| `bay plan` | the plan and every limit — the answer to every 402 |
| `bay tokens` | every CLI signed in, and revoking one |

No new endpoint: `lib/session.ts` resolves a Bearer token exactly where it resolves a session cookie. One additive server change — the domains route now returns the DNS record itself, so a published npm package does not carry a second copy of the apex-vs-subdomain rule.

## The command is `bay`, the word is `ship`

Nothing about the old name stops working and none of it is deprecated: `supersonic` is still installed as a binary, `~/.supersonic` is still read, `SUPERSONIC_TOKEN`/`_URL`/`_WHO` are still honoured beside the `BAY_` names. `lib/home.js` holds that rule; `test/home.test.js` pins it, including the empty-`BAY_TOKEN` case that would otherwise shadow a working old one.

Not renamed, deliberately: `supersonic.json`, `x-supersonic-*`, `SUPERSONIC_RUN`, `SUPERSONIC_CODE_*` and the scrypt salt — those are read by the control plane, and the salt is half of a key `apps/web/lib/deploy-runs.ts` derives from the same literal.

## Fixed on the way

- **`check` claimed every service started from a Dockerfile.** It asked whether the lane was `container`, and after the buildpack lane was removed that means all of them. Its test was red before this branch — and `prepublishOnly` runs the suite, so no CLI could be published while it stood.
- **`open` and `status` knew one domain.** They built `https://<app>.supersonic.cv` inside a published package; they ask the API now.

## Verification

- `packages/cli`: **127/127** (`npm test`)
- `apps/landing`: `next build` clean
- `apps/web`: `tsc --noEmit` clean
- Live prod smoke: `apps`, `plan`, `tokens`, `share`, `domains`, `git`, `status`, `--json`, plus a reversible write round-trip
- Not exercised live: `bay db` — neither of my apps provisions a database. Table rendering is unit-tested.

Nothing here is deployed. `curl thebay.cloud` needs an apps/landing deploy; the `record` field needs apps/web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUYPQ1Gwkx8JrmJDQCLf14