### PR TITLE
Analytics counted nobody, and three separate things had to be true for that

### DIFF
--- a/apps/web/components/panel/Dev.tsx
+++ b/apps/web/components/panel/Dev.tsx
@@ -448,25 +448,111 @@ function ScreenBody({ d, slug, view }: { d: Reading; slug: string; view: View })
     );
   }
   // analytics
+  return <AnalyticsScreen d={d} slug={slug} />;
+}
+
+/**
+ * The Analytics screen: the four numbers, then WHERE and WHENCE.
+ *
+ * The lists are the reason this screen exists at all. Four totals tell an owner
+ * that somebody came; the pages and the referrers tell them what for and from
+ * where, which is the only part anybody acts on. Both were already being fetched
+ * on every read of this screen and thrown away one function upstream, so drawing
+ * them costs no request that was not already being made.
+ *
+ * The switch is here rather than in settings for the reason the route it calls
+ * gives: this is other people's users' data, and an owner who does not want
+ * their visitors counted has to be able to say so from the same surface that
+ * shows them the count. The route and `setAnalyticsEnabled` have existed since
+ * the day analytics shipped with nothing anywhere calling them.
+ */
+function AnalyticsScreen({ d, slug }: { d: Reading; slug: string }) {
+  // Seeded from the reading, then owned here: the reading is re-derived from a
+  // poll that lags the write by up to its own interval, and a switch that flicks
+  // back under the finger is a switch nobody trusts again.
+  const [on, setOn] = useState(d.anOn);
+  const [saving, setSaving] = useState(false);
+
+  async function flip(next: boolean) {
+    setSaving(true);
+    setOn(next);
+    try {
+      const r = await fetch(`/api/apps/${encodeURIComponent(slug)}/analytics`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!r.ok) throw new Error(String(r.status));
+      // The edge caches app rows for thirty seconds, so the tracker keeps being
+      // injected for up to that long after the switch is off. Said out loud
+      // rather than discovered by an owner who flipped it and reloaded twice.
+      toast(next ? "Counting visitors again." : "Off. The last pages already served still count, for up to 30s.");
+    } catch {
+      setOn(!next);
+      toast("That did not save. Nothing changed.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
-    <Card className="flex flex-col gap-2 rounded-xl border-border bg-card p-4 shadow-none">
-      {d.an ? (
-        <div className="grid grid-cols-2 gap-4">
-          <Stat label="visitors" value={d.an.visitors.toLocaleString()} />
-          <Stat label="views" value={d.an.views.toLocaleString()} />
-          <Stat label="bounce" value={d.an.returning} />
-          <Stat label="change" value={d.an.dv || "—"} />
+    <div className="flex flex-col gap-3">
+      <Card className="flex flex-col gap-4 rounded-xl border-border bg-card p-4 shadow-none">
+        {d.an ? (
+          <>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <Stat label="visitors" value={d.an.visitors.toLocaleString()} />
+              <Stat label="views" value={d.an.views.toLocaleString()} />
+              <Stat label="bounce" value={d.an.bounce} />
+              <Stat label="change" value={d.an.dv || "—"} />
+            </div>
+            <div className="grid gap-6 sm:grid-cols-2">
+              <RankList title="Pages" rows={d.an.pages} empty="No page has been opened yet." />
+              <RankList title="From" rows={d.an.from} empty="Nobody arrived from a link yet." />
+            </div>
+          </>
+        ) : (
+          <p className="text-sub text-ink-2">
+            {!on
+              ? "Analytics is off, so nobody is being counted."
+              : !d.anReady
+                ? "Analytics is still being set up for this app."
+                : "The count could not be read just now — which is not the same as nobody having visited."}
+          </p>
+        )}
+      </Card>
+      <Card className="flex items-center justify-between gap-4 rounded-xl border-border bg-card p-4 shadow-none">
+        <div className="flex flex-col gap-0.5">
+          <div className="text-val text-ink">Count visitors</div>
+          <p className="text-sub text-ink-2">
+            First-party, from this app&apos;s own address. No cookie, no third-party script, and nothing
+            leaves the hostname your visitors already chose to trust.
+          </p>
         </div>
+        <Button variant="outline" size="sm" disabled={saving} onClick={() => flip(!on)}>
+          {on ? "Turn off" : "Turn on"}
+        </Button>
+      </Card>
+    </div>
+  );
+}
+
+/** One ranked list. Empty says so in words — an empty box is a broken box. */
+function RankList({ title, rows, empty }: { title: string; rows: [string, number][]; empty: string }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="text-[13px] text-ink-3">{title}</div>
+      {rows.length === 0 ? (
+        <p className="text-sub text-ink-2">{empty}</p>
       ) : (
-        <p className="text-sub text-ink-2">
-          {!d.anOn
-            ? "Analytics is off, so nobody is being counted."
-            : !d.anReady
-              ? "Analytics is still being set up for this app."
-              : "The count could not be read just now — which is not the same as nobody having visited."}
-        </p>
+        rows.map(([name, n]) => (
+          <div key={name} className="flex items-baseline justify-between gap-3">
+            <span className="truncate text-val text-ink">{name}</span>
+            <span className="text-val text-ink-2 tabular-nums">{n.toLocaleString()}</span>
+          </div>
+        ))
       )}
-    </Card>
+    </div>
   );
 }
 

--- a/apps/web/lib/apps.ts
+++ b/apps/web/lib/apps.ts
@@ -89,8 +89,31 @@ export async function createAppRecord(o: {
  * the control plane deploys ahead of migrations, and a deploy must not start
  * failing in the window between the two.
  */
+let saidUnconfigured = false;
+
 async function provisionAnalytics(slug: string): Promise<void> {
-  if (!umamiConfigured()) return;
+  if (!umamiConfigured()) {
+    // ONCE PER PROCESS, AND IT IS THE LOG THIS FUNCTION WAS MISSING.
+    //
+    // `createAppRecord` runs wherever a deploy runs, and a deploy runs in three
+    // services: the control plane, the warm deploy worker and the deploy job.
+    // Only the first had UMAMI_URL — the other two were configured by copying
+    // the control plane's env once, before analytics existed, and env copied
+    // once is env that drifts. So an app got analytics or did not according to
+    // which service happened to deploy it, and this branch returned in silence
+    // either way: two live apps had no site at all and nothing anywhere said so.
+    //
+    // cloudbuild.yaml now carries UMAMI_URL/UMAMI_USER in _LANE_ENV and the
+    // password as a secret on all three, which is the fix. This line is what
+    // makes the next drift of this shape audible instead of invisible.
+    if (!saidUnconfigured) {
+      saidUnconfigured = true;
+      console.error(
+        `analytics: UMAMI_URL/UMAMI_PASSWORD are not set in this service — ${slug} and everything it deploys will have no site`
+      );
+    }
+    return;
+  }
   try {
     const cur = await getPool(DB).query(
       `SELECT umami_website_id FROM apps WHERE slug = $1`,
@@ -98,7 +121,14 @@ async function provisionAnalytics(slug: string): Promise<void> {
     );
     if (cur.rows[0]?.umami_website_id) return;
     const id = await ensureWebsite(slug);
-    if (!id) return;
+    // `ensureWebsite` already logs WHY it could not answer; this says which app
+    // paid for it. It used to be a bare `return`, so the one outcome an owner
+    // actually feels — this app has no analytics — was the one outcome that
+    // wrote nothing anywhere.
+    if (!id) {
+      console.error(`analytics: no site for ${slug} — umami did not answer`);
+      return;
+    }
     await getPool(DB).query(
       `UPDATE apps SET umami_website_id = $2 WHERE slug = $1 AND umami_website_id IS NULL`,
       [slug, id]
@@ -351,7 +381,7 @@ export async function removeGrant(slug: string, email: string): Promise<void> {
   );
 }
 
-// Domain rules — "anyone with an @luwo.ai address". Stored per app, beside the
+// Domain rules — "anyone with an @acme.com address". Stored per app, beside the
 // people invited by name, and read by the edge with SQL equality (see
 // `normalizeDomain` in lib/workspace.ts for why equality and not a suffix).
 

--- a/apps/web/lib/panel/reading.ts
+++ b/apps/web/lib/panel/reading.ts
@@ -45,9 +45,17 @@ export type Reading = {
     visitors: number;
     views: number;
     mins: string;
-    returning: string;
+    /** Share of sessions that were one page and gone, as a percentage. */
+    bounce: string;
+    /** Change in visitors against the window before, e.g. "+40%". Empty when
+     *  the previous window had nobody in it: percent change from zero is
+     *  infinity, and every honest rendering of it is a sentence, not a number. */
     dv: string;
     dvUp: boolean;
+    /** Ranked, already trimmed. Empty is an ANSWER — nobody visited a page yet;
+     *  the read failing is `an: null`, which the screen says differently. */
+    pages: [string, number][];
+    from: [string, number][];
   } | null;
   anOn: boolean;
   anReady: boolean;
@@ -136,6 +144,37 @@ function tableRow(t: Json | string): [string, number] {
   const name = t.table_name ?? t.tablename ?? t.name ?? String(t);
   const n = t.n_live_tup ?? t.rows ?? 0;
   return [String(name), Number(n) || 0];
+}
+
+/**
+ * A ranked list from umami, trimmed and made presentable.
+ *
+ * `x` is null or empty for a direct visit with no referrer, which is most of
+ * them for an app somebody shared as a link; it becomes "direct" rather than
+ * being dropped, because "where did they come from" with the largest answer
+ * missing is worse than useless. A `null` list — umami refused the question —
+ * is empty here, and the caller says which it was from `an` being null or not.
+ */
+export function rank(rows: { x: string | null; y: number }[] | null | undefined, blank: string): [string, number][] {
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .filter((r) => typeof r?.y === "number" && r.y > 0)
+    .slice(0, 6)
+    .map((r) => [r.x && String(r.x).trim() ? String(r.x) : blank, Math.round(r.y)] as [string, number]);
+}
+
+/**
+ * Percent change against the previous window, or "" when there is nothing to
+ * compare against. Zero visitors last week and two this week is not "+200%" and
+ * not "+0%" — it is a comparison that cannot be drawn, and an empty string is
+ * what the tile renders as "—".
+ */
+export function change(now: number | undefined, prev: number | undefined): string {
+  const a = now ?? 0;
+  const b = prev ?? 0;
+  if (b <= 0) return "";
+  const pct = Math.round(((a - b) / b) * 100);
+  return `${pct >= 0 ? "+" : ""}${pct}%`;
 }
 
 function keyName(k: Json | string): string {
@@ -244,10 +283,20 @@ export function deriveReading(slug: string, addr: string, raw: Raw): Reading {
           views: stats.views,
           mins: String(Math.round((stats.totalTime || 0) / Math.max(stats.visits || 1, 1))),
           // Umami gives bounces and visits, not a returning count. Say what the
-          // number is rather than what we wished it were.
-          returning: `${Math.round(((stats.bounces || 0) / Math.max(stats.visits || 1, 1)) * 100)}%`,
-          dv: "",
-          dvUp: true,
+          // number is rather than what we wished it were — this tile was fed by
+          // a field called `returning` and labelled "bounce", which is two
+          // people's worth of confusion for one number.
+          bounce: `${Math.round(((stats.bounces || 0) / Math.max(stats.visits || 1, 1)) * 100)}%`,
+          // Against the window before this one, which /stats already carries in
+          // whichever of its three shapes this umami speaks. It was hardcoded to
+          // "" and the tile therefore always read "—", on every app, forever.
+          dv: change(stats.visitors, stats.prevVisitors),
+          dvUp: (stats.visitors ?? 0) >= (stats.prevVisitors ?? 0),
+          // Fetched since the day this screen shipped and thrown away here. The
+          // reader asks umami for both lists on every read, so drawing them costs
+          // no request that was not already made.
+          pages: rank(stats.pages, "/"),
+          from: rank(stats.referrers, "direct"),
         }
       : null,
     anOn: an.enabled !== false,

--- a/apps/web/lib/umami.ts
+++ b/apps/web/lib/umami.ts
@@ -19,7 +19,7 @@
  */
 
 import { identityToken } from "./gcp-rest";
-import { rootDomain } from "./roots";
+import { rootDomain, rootDomains } from "./roots";
 import { memo } from "./memo";
 
 const BASE = (process.env.UMAMI_URL ?? "").replace(/\/$/, "");
@@ -163,7 +163,22 @@ export async function ensureWebsite(slug: string): Promise<string | null> {
 
   const existing = await listWebsites();
   if (existing === null) return null; // could not ask; do not create a duplicate
-  const hit = existing.find((w) => w.domain === domain);
+  // MATCHED AGAINST EVERY ROOT, NOT ONLY THE CANONICAL ONE.
+  //
+  // A website is created under whichever root was canonical that day, and the
+  // canonical root CHANGED — every site in the running instance is registered
+  // as `<slug>.supersonic.cv` while new ones would be `<slug>.thebay.cloud`.
+  // Looking up by the canonical name alone therefore misses every existing site
+  // the moment a rename lands, and this function's answer to "not found" is to
+  // CREATE ONE: a second site for the same app, which the panel would then read
+  // while the app's real visitors went on arriving in the first. Silent, and
+  // indistinguishable from an app nobody visits.
+  //
+  // The name is matched too, because that is what an operator sees in umami and
+  // what the backfill wrote; the roots are matched because that is what this
+  // function itself wrote. Either is proof the app already has a site.
+  const names = new Set(rootDomains().map((r) => `${slug}.${r}`));
+  const hit = existing.find((w) => names.has(w.domain) || w.name === slug);
   if (hit) return hit.id;
 
   const r = await api(`/api/websites`, {
@@ -199,8 +214,96 @@ export interface WebsiteStats {
   visits: number;
   bounces: number;
   totalTime: number;
-  pages: { x: string; y: number }[];
-  referrers: { x: string; y: number }[];
+  /**
+   * The same window, one window earlier — so a caller can say "up 40%" without
+   * asking twice. Zero when this umami offers no comparison at all, which is a
+   * reason to show no change rather than to show a change of nothing.
+   */
+  prevVisitors: number;
+  prevViews: number;
+  /**
+   * `null` means the list could not be read, and that is NOT an empty list.
+   *
+   * This is the distinction whose absence hid the metric rename for weeks: a
+   * 400 was turned into `[]` here and rendered as "no pages", so the panel said
+   * nobody had visited any page of an app with 179 page views. Every caller has
+   * to tell the two apart, which it can only do if this stays nullable.
+   */
+  pages: { x: string; y: number }[] | null;
+  referrers: { x: string; y: number }[] | null;
+}
+
+/**
+ * THREE SHAPES OF /stats, AND THIS IS NOT DEFENSIVENESS FOR ITS OWN SAKE.
+ *
+ * Umami has rewritten this response twice and every version is deployed
+ * somewhere:
+ *
+ *   flat      {"pageviews":179,"visitors":10,"comparison":{"visitors":0}}
+ *   paired    {"pageviews":{"value":179,"prev":22}}
+ *   delta     {"pageviews":{"value":179,"change":157}}
+ *
+ * The instance running in front of us today is the FLAT one — verified against
+ * it on 24 Aug: `{"pageviews":179,"visitors":10,"visits":35,...}`. This module
+ * read `m.value` and nothing else, and `.value` on a number is `undefined`, so
+ * every figure came back 0 and the panel drew a confident "0 visitors" over an
+ * app with ten of them. That is the failure the `null`-versus-zero rule exists
+ * to prevent, arriving through the one door it does not cover: a read that
+ * SUCCEEDS and means nothing.
+ *
+ * The edge parses the same three shapes for the same reason
+ * (services/proxy/src/analytics.ts). Two copies because the two run in different
+ * services with no shared package between them; they are kept identical on
+ * purpose, and a change to one belongs in both.
+ */
+type Metric = number | { value?: number; prev?: number; change?: number } | undefined;
+
+const num = (m: Metric): number => (typeof m === "number" ? Math.round(m) : Math.round(m?.value ?? 0));
+
+/** The same metric over the window BEFORE this one, however this build reports it. */
+function before(m: Metric, comparison: Record<string, number> | undefined, key: string): number {
+  // Flat: the previous window is a sibling object under the same name, and it
+  // is reported as the previous VALUE, not as a delta.
+  if (typeof m === "number") return Math.round(comparison?.[key] ?? 0);
+  if (typeof m?.prev === "number") return Math.round(m.prev);
+  // The delta shape reports the CHANGE, so the previous window is value − change.
+  if (typeof m?.change === "number" && typeof m?.value === "number") return Math.round(m.value - m.change);
+  return 0;
+}
+
+interface Stats {
+  pageviews?: Metric; visitors?: Metric; uniques?: Metric;
+  visits?: Metric; bounces?: Metric; totaltime?: Metric;
+  comparison?: Record<string, number>;
+}
+
+/**
+ * One ranked list, under whichever name this umami calls it.
+ *
+ * Tries the names in order and returns the first that ANSWERS. An empty list is
+ * an answer and stops the search; only a refusal moves on. `null` when none of
+ * them answered — see WebsiteStats.pages for why that is not `[]`.
+ *
+ * `type=path` first, `type=url` behind it: umami renamed this metric and the
+ * old name is not deprecated but REJECTED — `type=url` answers 400 on the
+ * instance running today while `type=path` returns the data. Neither name is
+ * right on every version, so both are tried rather than one being guessed at.
+ */
+async function metricList(
+  websiteId: string,
+  q: string,
+  types: string[],
+): Promise<{ x: string; y: number }[] | null> {
+  for (const type of types) {
+    const r = await api(`/api/websites/${websiteId}/metrics?${q}&type=${type}&limit=10`);
+    if (r && r.ok) {
+      const j = (await r.json().catch(() => null)) as { x: string; y: number }[] | null;
+      if (Array.isArray(j)) return j;
+      return null;
+    }
+    if (r) console.error(`umami: metrics type=${type} for ${websiteId} — ${r.status}`);
+  }
+  return null;
 }
 
 /**
@@ -238,39 +341,33 @@ export async function websiteStats(
   const startAt = endAt - span;
   const q = `startAt=${startAt}&endAt=${endAt}`;
 
-  const [statsRes, pagesRes, refsRes] = await Promise.all([
+  const [statsRes, pages, referrers] = await Promise.all([
     api(`/api/websites/${websiteId}/stats?${q}`),
-    // `path`, not `url`. Umami renamed this metric type, and the old name is not
-    // deprecated — it is rejected: `type=url` answers 400 Bad request while
-    // `type=path` returns the data. Verified against the running instance
-    // (`postgresql-latest`) on 24 Aug: url 400, path [{"x":"/","y":2}].
-    //
-    // The 400 was invisible because `list()` below turns any non-ok response
-    // into `[]`, which is indistinguishable from "this site has no pages yet".
-    // So the pages panel has been empty for every app for as long as this ran,
-    // and nothing anywhere said why. Every other type — referrer, browser, os,
-    // device, country — was and is fine.
-    api(`/api/websites/${websiteId}/metrics?${q}&type=path&limit=10`),
-    api(`/api/websites/${websiteId}/metrics?${q}&type=referrer&limit=10`),
+    metricList(websiteId, q, ["path", "url"]),
+    metricList(websiteId, q, ["referrer"]),
   ]);
-  if (!statsRes || !statsRes.ok) return null;
+  if (!statsRes || !statsRes.ok) {
+    if (statsRes) console.error(`umami: stats for ${websiteId} — ${statsRes.status}`);
+    return null;
+  }
 
-  // umami answers each figure as { value, prev }; only the value is wanted here.
-  const s = (await statsRes.json().catch(() => null)) as Record<string, { value?: number }> | null;
+  const s = (await statsRes.json().catch(() => null)) as Stats | null;
   if (!s) return null;
-  const n = (k: string) => Number(s[k]?.value ?? 0);
 
-  const list = async (r: Response | null) =>
-    r && r.ok ? (((await r.json().catch(() => [])) as { x: string; y: number }[]) ?? []) : [];
-
+  const visitors = num(s.visitors ?? s.uniques);
   return {
     range,
-    visitors: n("visitors"),
-    views: n("pageviews"),
-    visits: n("visits"),
-    bounces: n("bounces"),
-    totalTime: n("totaltime"),
-    pages: await list(pagesRes),
-    referrers: await list(refsRes),
+    visitors,
+    views: num(s.pageviews),
+    visits: num(s.visits),
+    bounces: num(s.bounces),
+    totalTime: num(s.totaltime),
+    prevVisitors: before(s.visitors ?? s.uniques, s.comparison, s.visitors !== undefined ? "visitors" : "uniques"),
+    prevViews: before(s.pageviews, s.comparison, "pageviews"),
+    pages,
+    referrers,
   };
 }
+
+/** Test seam: the parsers above, exercised without a network. */
+export const __test = { num, before };

--- a/apps/web/test/panel-reading.test.ts
+++ b/apps/web/test/panel-reading.test.ts
@@ -53,3 +53,83 @@ test("a failed deploy becomes the alert, and a broken path outranks it", () => {
   };
   assert.match(deriveReading("l3sgp", "a", both).alert?.title ?? "", /\/checkout has been failing/);
 });
+
+/* ==========================================================================
+   THE ANALYTICS HALF
+
+   Everything below is about one screen that had four numbers on it, two of
+   which were wrong: `change` was hardcoded to the empty string and therefore
+   always rendered "—", and the tile labelled "bounce" was fed a field called
+   `returning`. The two lists the reader already fetched — pages and referrers —
+   were dropped on the floor one function above the screen that wanted them.
+   ========================================================================== */
+
+const STATS = {
+  range: "30d",
+  visitors: 10,
+  views: 179,
+  visits: 35,
+  bounces: 16,
+  totalTime: 19970,
+  prevVisitors: 4,
+  prevViews: 100,
+  pages: [{ x: "/", y: 10 }, { x: "/v", y: 1 }],
+  referrers: [{ x: "app.supersonic.cv", y: 2 }, { x: "", y: 1 }],
+};
+
+test("the analytics screen reads every number it draws", () => {
+  const d = deriveReading("l3sgp", "l3sgp.supersonic.cv", {
+    an: { enabled: true, provisioned: true, stats: STATS },
+  } as Raw);
+  assert.ok(d.an);
+  assert.equal(d.an.visitors, 10);
+  assert.equal(d.an.views, 179);
+  // 16 bounces over 35 sessions. The number is a bounce rate and now says so.
+  assert.equal(d.an.bounce, "46%");
+  // 10 visitors against 4 in the window before: +150%, which the tile has never
+  // once shown because this field was the empty string in the source.
+  assert.equal(d.an.dv, "+150%");
+  assert.equal(d.an.dvUp, true);
+  assert.deepEqual(d.an.pages, [["/", 10], ["/v", 1]]);
+  // A referrer with no name is a direct visit, which is most of them for an app
+  // somebody shared as a link — dropping it would put the largest answer to
+  // "where did they come from" nowhere on the screen.
+  assert.deepEqual(d.an.from, [["app.supersonic.cv", 2], ["direct", 1]]);
+});
+
+test("a fall is a fall, and no previous window is no percentage at all", () => {
+  const down = deriveReading("x", "x.dev", {
+    an: { enabled: true, provisioned: true, stats: { ...STATS, visitors: 2, prevVisitors: 8 } },
+  } as Raw);
+  assert.equal(down.an?.dv, "-75%");
+  assert.equal(down.an?.dvUp, false);
+
+  const fresh = deriveReading("x", "x.dev", {
+    an: { enabled: true, provisioned: true, stats: { ...STATS, prevVisitors: 0 } },
+  } as Raw);
+  // Percent change from zero is infinity. "" renders as "—", which is the only
+  // honest thing to draw in a box that small.
+  assert.equal(fresh.an?.dv, "");
+});
+
+test("a list umami refused is empty here, and the screen says so through `an`", () => {
+  const d = deriveReading("x", "x.dev", {
+    an: { enabled: true, provisioned: true, stats: { ...STATS, pages: null, referrers: null } },
+  } as Raw);
+  assert.deepEqual(d.an?.pages, []);
+  assert.deepEqual(d.an?.from, []);
+  // The headline numbers are still true, and are still drawn. A missing column
+  // beside a real visitor count is a worse reading, not an unreadable one.
+  assert.equal(d.an?.visitors, 10);
+});
+
+test("off and unprovisioned are told apart, and neither is zero visitors", () => {
+  const off = deriveReading("x", "x.dev", { an: { enabled: false, provisioned: true, stats: null } } as Raw);
+  assert.equal(off.an, null);
+  assert.equal(off.anOn, false);
+  assert.equal(off.anReady, true);
+
+  const unready = deriveReading("x", "x.dev", { an: { enabled: true, provisioned: false, stats: null } } as Raw);
+  assert.equal(unready.anOn, true);
+  assert.equal(unready.anReady, false);
+});

--- a/apps/web/test/umami-stats.test.ts
+++ b/apps/web/test/umami-stats.test.ts
@@ -1,0 +1,205 @@
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * What umami actually answers, and what this module made of it.
+ *
+ * The bug these exist for: `/stats` came back FLAT — `{"pageviews":179,
+ * "visitors":10}` — and the reader asked for `m.value`, which on a number is
+ * `undefined`. Every figure became 0, so the panel drew a confident "0 visitors"
+ * over an app with ten. A read that succeeds and means nothing is worse than a
+ * read that fails, because nothing downstream can tell.
+ *
+ * Env before import: the module reads UMAMI_URL and UMAMI_PASSWORD at module
+ * scope, and a hostname that is not *.run.app is what keeps `invoker()` from
+ * reaching for a Google identity token that no test has.
+ */
+process.env.UMAMI_URL = "http://umami.test";
+process.env.UMAMI_PASSWORD = "hunter2";
+process.env.UMAMI_USER = "admin";
+
+/**
+ * Imported lazily, and inside a test rather than at the top: the file is
+ * transformed to CJS by tsx, which has no top-level await, and the module has to
+ * be loaded AFTER the variables above are set because it reads them at module
+ * scope.
+ */
+type Umami = typeof import("../lib/umami");
+let mod: Umami | null = null;
+async function lib(): Promise<Umami> {
+  mod ??= await import("../lib/umami");
+  return mod;
+}
+
+type Answer = { status?: number; body: unknown };
+let routes: Record<string, Answer>;
+let asked: string[];
+
+/** Every call the module makes, answered from a table and recorded. */
+function stubFetch() {
+  asked = [];
+  (globalThis as { fetch: unknown }).fetch = async (url: string | URL, init?: { method?: string }) => {
+    const u = String(url);
+    asked.push(`${init?.method ?? "GET"} ${u.replace("http://umami.test", "")}`);
+    if (u.includes("/api/auth/login")) {
+      return new Response(JSON.stringify({ token: "jwt" }), { status: 200 });
+    }
+    for (const [frag, a] of Object.entries(routes)) {
+      if (u.includes(frag)) {
+        return new Response(JSON.stringify(a.body), { status: a.status ?? 200 });
+      }
+    }
+    return new Response("{}", { status: 404 });
+  };
+}
+
+beforeEach(() => {
+  routes = {};
+  stubFetch();
+});
+
+const FLAT = {
+  pageviews: 179,
+  visitors: 10,
+  visits: 35,
+  bounces: 16,
+  totaltime: 19970,
+  comparison: { pageviews: 100, visitors: 4 },
+};
+
+test("the flat shape — the one running in production — is read, not zeroed", async () => {
+  routes = {
+    "/stats?": { body: FLAT },
+    "type=path": { body: [{ x: "/", y: 10 }] },
+    "type=referrer": { body: [] },
+  };
+  const { websiteStats } = await lib();
+  const s = await websiteStats("w1", "30d");
+  assert.ok(s);
+  assert.equal(s.visitors, 10);
+  assert.equal(s.views, 179);
+  assert.equal(s.visits, 35);
+  assert.equal(s.bounces, 16);
+  // The previous window is a SIBLING object in this shape, not a `prev` field.
+  assert.equal(s.prevVisitors, 4);
+  assert.equal(s.prevViews, 100);
+});
+
+test("the paired shape is read the same way", async () => {
+  routes = {
+    "/stats?": { body: { pageviews: { value: 179, prev: 100 }, visitors: { value: 10, prev: 4 } } },
+    "type=": { body: [] },
+  };
+  const { websiteStats } = await lib();
+  const s = await websiteStats("w1");
+  assert.ok(s);
+  assert.equal(s.visitors, 10);
+  assert.equal(s.views, 179);
+  assert.equal(s.prevVisitors, 4);
+});
+
+test("the delta shape reports the change, so the previous window is value minus it", async () => {
+  routes = {
+    "/stats?": { body: { pageviews: { value: 179, change: 79 }, visitors: { value: 10, change: 6 } } },
+    "type=": { body: [] },
+  };
+  const { websiteStats } = await lib();
+  const s = await websiteStats("w1");
+  assert.ok(s);
+  assert.equal(s.prevVisitors, 4);
+  assert.equal(s.prevViews, 100);
+});
+
+test("`uniques` is read when this build has no `visitors`", async () => {
+  routes = { "/stats?": { body: { pageviews: 5, uniques: 3, comparison: { uniques: 1 } } }, "type=": { body: [] } };
+  const { websiteStats } = await lib();
+  const s = await websiteStats("w1");
+  assert.equal(s?.visitors, 3);
+  assert.equal(s?.prevVisitors, 1);
+});
+
+test("pages fall back from `path` to `url`, because the name changed under us", async () => {
+  routes = {
+    "/stats?": { body: FLAT },
+    "type=path": { status: 400, body: { error: "Bad request" } },
+    "type=url": { body: [{ x: "/", y: 3 }] },
+    "type=referrer": { body: [] },
+  };
+  const { websiteStats } = await lib();
+  const s = await websiteStats("w1");
+  assert.deepEqual(s?.pages, [{ x: "/", y: 3 }]);
+  assert.ok(asked.some((a) => a.includes("type=path")), "path is tried first");
+  assert.ok(asked.some((a) => a.includes("type=url")), "url is tried after the refusal");
+});
+
+test("a refused list is null, and an empty one is empty — they are not the same answer", async () => {
+  routes = {
+    "/stats?": { body: FLAT },
+    "type=path": { status: 500, body: {} },
+    "type=url": { status: 400, body: {} },
+    "type=referrer": { body: [] },
+  };
+  const { websiteStats } = await lib();
+  const s = await websiteStats("w1");
+  // THE BUG THIS FILE IS NAMED FOR. `[]` here would render as "no pages", which
+  // is a claim about the app; null renders as nothing, which is the truth.
+  assert.equal(s?.pages, null);
+  assert.deepEqual(s?.referrers, []);
+});
+
+test("a refused /stats is null overall — never a row of zeroes", async () => {
+  routes = { "/stats?": { status: 500, body: {} }, "type=": { body: [] } };
+  const { websiteStats } = await lib();
+  assert.equal(await websiteStats("w1"), null);
+});
+
+test("the parsers, on their own", async () => {
+  const { __test } = await lib();
+  assert.equal(__test.num(7), 7);
+  assert.equal(__test.num({ value: 7 }), 7);
+  assert.equal(__test.num(undefined), 0);
+  assert.equal(__test.before(7, { visitors: 3 }, "visitors"), 3);
+  assert.equal(__test.before({ value: 7, prev: 3 }, undefined, "visitors"), 3);
+  assert.equal(__test.before({ value: 7, change: 4 }, undefined, "visitors"), 3);
+  // No comparison offered at all is 0, which every caller reads as "nothing to
+  // compare against" rather than as a previous window that was empty.
+  assert.equal(__test.before(7, undefined, "visitors"), 0);
+});
+
+/* ==========================================================================
+   PROVISIONING, WHICH IS THE HALF THAT DECIDES WHETHER THERE IS ANYTHING TO READ
+   ========================================================================== */
+
+test("an app that already has a site under the OLD root does not get a second one", async () => {
+  const { ensureWebsite } = await lib();
+  routes = {
+    "/api/websites?": {
+      body: { data: [{ id: "w-old", name: "l3sgp", domain: "l3sgp.supersonic.cv" }] },
+    },
+  };
+  const id = await ensureWebsite("l3sgp");
+  assert.equal(id, "w-old");
+  // THE FAILURE THIS PREVENTS: a POST here mints a second site for the same app,
+  // the panel reads the empty new one, and the visitors go on arriving in the
+  // old one. Nothing anywhere says so.
+  assert.ok(!asked.some((a) => a.startsWith("POST /api/websites")), "no site was created");
+});
+
+test("an app with no site anywhere gets one, under the canonical root", async () => {
+  const { ensureWebsite } = await lib();
+  routes = {
+    "/api/websites?": { body: { data: [] } },
+    "/api/websites": { body: { id: "w-new" } },
+  };
+  assert.equal(await ensureWebsite("qjl80"), "w-new");
+  assert.ok(asked.some((a) => a.startsWith("POST /api/websites")));
+});
+
+test("umami not answering the list creates nothing at all", async () => {
+  const { ensureWebsite } = await lib();
+  routes = { "/api/websites?": { status: 500, body: {} } };
+  assert.equal(await ensureWebsite("qjl80"), null);
+  // "Could not ask" must never become "does not exist" — that is how one
+  // unreachable minute turns into a duplicate site per deploy.
+  assert.ok(!asked.some((a) => a.startsWith("POST /api/websites")));
+});

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,6 +79,7 @@ steps:
         fi
         gcloud run jobs update supersonic-deploy-job \
           --image=$_IMAGE:$_TAG --update-env-vars=$_LANE_ENV \
+          --update-secrets=UMAMI_PASSWORD=umami-admin-password:latest \
           --region=us-central1 --project=$PROJECT_ID --quiet
 
   # The warm deploy worker is the same image again, with a third command, and it
@@ -122,12 +123,26 @@ steps:
         # even though `gcloud run deploy` preserves the live value: this file is
         # what recreates the service after `setup-deploy-worker.sh` is rerun or
         # the service is deleted. See docs/HANDOFF-deploy-agent-sandbox.md.
+        # UMAMI_PASSWORD, and it is here because of what its absence did.
+        #
+        # An app gets its analytics site from `createAppRecord`, which runs
+        # wherever the deploy runs — the control plane, this worker, or the job.
+        # Only the control plane was ever given UMAMI_URL and the password: these
+        # two were configured by copying the control plane's environment ONCE,
+        # before analytics existed, and a copy taken once is a copy that drifts.
+        # So an app got analytics or did not according to which of three services
+        # happened to deploy it, and the code returned in silence either way. Two
+        # live apps had no site at all on 24 Aug and nothing anywhere said so.
+        #
+        # `--update-secrets` merges, exactly like --update-env-vars: the other
+        # secrets this service carries are untouched.
         gcloud run deploy supersonic-deploy-worker \
           --image=$_IMAGE:$_TAG \
           --region=us-central1 --project=$PROJECT_ID \
           --execution-environment=gen2 \
           --update-env-vars=$_LANE_ENV \
           --update-env-vars=IMAGE_TAG=$_TAG \
+          --update-secrets=UMAMI_PASSWORD=umami-admin-password:latest \
           --quiet
 
   # Never env vars: the live service carries AUTH_SECRET, PG_PASSWORD, the Stripe
@@ -258,6 +273,10 @@ steps:
       # assertJobImageMatches states, for the same reason: this check exists to
       # catch a stale worker, not to become a fresh way for a deploy to fail.
       - --update-env-vars=IMAGE_TAG=$_TAG
+      # Set by hand on this service in July and by nothing since. Written down
+      # here for the same reason as the worker's: three services read it and one
+      # of them having it is indistinguishable, from the outside, from all three.
+      - --update-secrets=UMAMI_PASSWORD=umami-admin-password:latest
       - --quiet
 
 substitutions:
@@ -314,7 +333,7 @@ substitutions:
   #
   # Ours, throwaway, and its downtime belongs to nobody, which is the same reason
   # the entries it replaces were chosen.
-  _LANE_ENV: ^~~^PLANNER=1~~SEAL_APPS=1~~DEPLOY_ENGINE=opencode~~DEPLOY_JOB=1~~NODE_IDENTITY=enforce~~BUILDER=railpack~~BUILDKIT_HOST=tcp://10.128.0.5:1234~~BUILDKIT_IMAGE=us-central1-docker.pkg.dev/supersonic-deploy-prod/docker-hub/moby/buildkit:buildx-stable-1~~DOCKER_MIRROR=us-central1-docker.pkg.dev/supersonic-deploy-prod/docker-hub~~CLOUD_BUILD_RUN_AS=supersonic-build@supersonic-deploy-prod.iam.gserviceaccount.com
+  _LANE_ENV: ^~~^PLANNER=1~~SEAL_APPS=1~~DEPLOY_ENGINE=opencode~~DEPLOY_JOB=1~~NODE_IDENTITY=enforce~~BUILDER=railpack~~BUILDKIT_HOST=tcp://10.128.0.5:1234~~BUILDKIT_IMAGE=us-central1-docker.pkg.dev/supersonic-deploy-prod/docker-hub/moby/buildkit:buildx-stable-1~~DOCKER_MIRROR=us-central1-docker.pkg.dev/supersonic-deploy-prod/docker-hub~~CLOUD_BUILD_RUN_AS=supersonic-build@supersonic-deploy-prod.iam.gserviceaccount.com~~UMAMI_URL=https://supersonic-umami-uyuwsbguuq-uc.a.run.app~~UMAMI_USER=admin
   _IMAGE: us-central1-docker.pkg.dev/supersonic-deploy-prod/supersonic/control-plane
   # The commit being deployed. A trigger passes $SHORT_SHA; a manual `builds submit`
   # passes whatever it likes. The default keeps a hand-run build from failing on an

--- a/scripts/setup-umami.sh
+++ b/scripts/setup-umami.sh
@@ -120,15 +120,29 @@ say "cloud run service $SERVICE"
 # admin/umami password has to be changed. Two gates are only better than one
 # when both let the right callers through.
 #
-# min-instances 0: this is a background service with no latency budget of its
-# own. The tracker POST is fire-and-forget from the page's point of view, and the
-# panel's read is cached for a minute. A cold start costs nobody a render.
+# min-instances 1, AND THE REASONING THAT SAID 0 WAS WRONG.
+#
+# It said: a background service with no latency budget of its own — the tracker
+# POST is fire-and-forget and the panel's read is cached for a minute, so a cold
+# start costs nobody a render. Both halves of that are true and the conclusion
+# did not follow, because the read is not the only thing that has to happen
+# first. A cold umami has to LOG IN, and a login here is a container start plus a
+# Prisma connection plus one bcrypt: 13, 20, 25 and 26 seconds, measured against
+# this service on 24 Aug (warm: 90–440ms). Nothing that a person is waiting on
+# can absorb that, so the edge gave up at ten seconds and told owners their
+# visitors could not be counted — and because analytics is looked at rarely, the
+# cold path was the ONLY path most owners ever took.
+#
+# The edge no longer waits for a login (services/proxy/src/analytics.ts), which
+# is the half of the fix that belongs in code. This is the other half: an
+# instance that is already up has nothing to wake. ~$8/month for a service whose
+# entire job is to be readable when somebody looks.
 gcloud run deploy "$SERVICE" \
   --image "$IMAGE" \
   --region "$REGION" --project "$PROJECT" \
   --ingress all \
   --no-allow-unauthenticated \
-  --min-instances 0 --max-instances 4 \
+  --min-instances 1 --max-instances 4 \
   --memory 1Gi --cpu 1 \
   --set-cloudsql-instances "$CONN" \
   --set-env-vars "DATABASE_TYPE=postgresql,TRACKER_SCRIPT_NAME=a,COLLECT_API_ENDPOINT=/a" \

--- a/services/proxy/src/analytics-login.test.ts
+++ b/services/proxy/src/analytics-login.test.ts
@@ -1,0 +1,78 @@
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * THE LOGIN IS NOT ON THE REQUEST PATH ANY MORE.
+ *
+ * Umami is a Next.js app on Cloud Run with no minimum instance, and a cold login
+ * is one container start plus one bcrypt: 13–26 seconds, measured against the
+ * running instance on 24 Aug. This module used to await that inside `/_xray`,
+ * behind a ten-second deadline, so every cold read aborted and the owner was
+ * told the count could not be read — while the service they were waiting on sat
+ * there hashing a password.
+ *
+ * The polled read now refuses immediately and lets the NEXT poll, three seconds
+ * later, find a warm token. These tests hold the login open forever to prove it:
+ * if `audienceFor` waited, this file would time out rather than fail.
+ */
+process.env.UMAMI_URL = "http://umami.test";
+process.env.UMAMI_PASSWORD = "hunter2";
+
+const { audienceFor, resetAudience } = await import("./analytics");
+
+let release: (() => void) | null = null;
+let logins = 0;
+
+/** A login that hangs until the test lets it finish; everything else is instant. */
+function stub() {
+  logins = 0;
+  release = null;
+  (globalThis as { fetch: unknown }).fetch = async (url: string | URL) => {
+    const u = String(url);
+    if (u.includes("/api/auth/login")) {
+      logins++;
+      await new Promise<void>((res) => (release = res));
+      return new Response(JSON.stringify({ token: "jwt" }), { status: 200 });
+    }
+    if (u.includes("/stats")) {
+      return new Response(JSON.stringify({ pageviews: 179, visitors: 10, visits: 35, bounces: 16, totaltime: 19970 }), { status: 200 });
+    }
+    return new Response(JSON.stringify([{ x: "/", y: 10 }]), { status: 200 });
+  };
+}
+
+beforeEach(() => {
+  resetAudience();
+  stub();
+});
+
+test("a cold read gives up at once instead of waiting for the login", async () => {
+  // No timing assertion and none needed: the stubbed login never resolves, so a
+  // version that awaited it could not reach the next line at all.
+  const a = await audienceFor("w1", 1_000_000);
+  assert.equal(a, null);
+  assert.equal(logins, 1, "and it started the login it declined to wait for");
+});
+
+test("the next poll finds the token and answers", async () => {
+  assert.equal(await audienceFor("w1", 1_000_000), null);
+  release?.();
+  await new Promise((r) => setTimeout(r, 10));
+
+  // A minute later by the clock this function is given — the cache holds the
+  // null for exactly as long as it holds a real reading.
+  const a = await audienceFor("w1", 1_000_000 + 61_000);
+  assert.ok(a, "the second read has a token and answers");
+  assert.equal(a.visitors, 10);
+  assert.equal(a.views, 179);
+  assert.equal(a.bounce, 46);
+  assert.equal(logins, 1, "one login, not one per read");
+});
+
+test("a hundred polls during a cold start cause one login between them", async () => {
+  const all = await Promise.all(Array.from({ length: 100 }, () => audienceFor("w1", 1_000_000)));
+  assert.ok(all.every((a) => a === null));
+  // Twenty simultaneous bcrypts on an instance sized for a 2 KB tracker is how
+  // the analytics falls over because somebody looked at the analytics.
+  assert.equal(logins, 1);
+});

--- a/services/proxy/src/analytics.ts
+++ b/services/proxy/src/analytics.ts
@@ -103,9 +103,11 @@ const WINDOW_MS = 24 * 60 * 60 * 1000;
 const CACHE_MS = 60_000;
 const cache = new Map<string, { at: number; value: Audience | null }>();
 
-/** Test seam, and the module's whole state. */
+/** Test seam, and the module's whole state — the cache AND the login. */
 export function resetAudience(): void {
   cache.clear();
+  token = null;
+  logging = null;
 }
 
 let token: { value: string; until: number } | null = null;
@@ -125,34 +127,80 @@ const TOKEN_MS = 6 * 60 * 60 * 1000;
  */
 let logging: Promise<string> | null = null;
 
-async function authToken(): Promise<string | null> {
-  if (token && Date.now() < token.until) return token.value;
-  if (logging) return logging;
+/**
+ * LONGER THAN ANY READ WILL EVER WAIT, AND THAT IS THE POINT.
+ *
+ * Umami is a Next.js app on Cloud Run, and a login is a container start plus a
+ * database connection plus one bcrypt. Measured against the running instance on
+ * 24 Aug: 13, 20, 25 and 26 seconds cold; 90–440ms warm. The old deadline here
+ * was ten seconds, so EVERY cold login aborted — and since the panel is opened
+ * by someone who has not looked at analytics recently, cold was the common case,
+ * not the edge one. The proxy logged "could not read … aborted due to timeout"
+ * and the owner was told their app might have no visitors.
+ *
+ * The fix is not a bigger deadline on the request path — a person waiting 26
+ * seconds for a number is its own failure. It is that the login no longer HAPPENS
+ * on the request path: see `warm` below.
+ */
+const LOGIN_MS = 60_000;
+
+async function login(): Promise<string> {
   const u = umami();
-  logging = (async () => {
-    const r = await fetch(`${u.url}/api/auth/login`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...(await invoker(u.url)) },
-      body: JSON.stringify({ username: u.user, password: u.password }),
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!r.ok) throw new Error(`umami login ${r.status}`);
-    const j = (await r.json()) as { token?: string };
-    if (!j.token) throw new Error("umami login returned no token");
-    token = { value: j.token, until: Date.now() + TOKEN_MS };
-    return j.token;
-  })();
-  try {
-    return await logging;
-  } finally {
-    // Cleared either way: holding a rejected promise here would make one failed
-    // login the permanent answer for every caller after it.
-    logging = null;
-  }
+  const r = await fetch(`${u.url}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(await invoker(u.url)) },
+    body: JSON.stringify({ username: u.user, password: u.password }),
+    signal: AbortSignal.timeout(LOGIN_MS),
+  });
+  if (!r.ok) throw new Error(`umami login ${r.status}`);
+  const j = (await r.json()) as { token?: string };
+  if (!j.token) throw new Error("umami login returned no token");
+  token = { value: j.token, until: Date.now() + TOKEN_MS };
+  return j.token;
 }
 
-async function get<T>(path: string, timeoutMs = 5000): Promise<T> {
-  const t = await authToken();
+/**
+ * Start a login if one is not already running, and DO NOT WAIT FOR IT.
+ *
+ * The panel polls every three seconds. So a read that finds no token can say
+ * "unreadable" now and be right three seconds later, which is a far better
+ * shape than holding one request open for the length of a container start. The
+ * next poll finds the token and answers in 90ms.
+ *
+ * The single-flight guard is unchanged and still load-bearing: the detail read
+ * makes twenty calls in one Promise.all, and twenty simultaneous logins are
+ * twenty bcrypts on an instance sized for a 2 KB tracker.
+ */
+function warm(): Promise<string> {
+  if (!logging) {
+    logging = login().finally(() => {
+      // Cleared either way: holding a rejected promise here would make one failed
+      // login the permanent answer for every caller after it.
+      logging = null;
+    });
+    // Nothing awaits the background copy, and an unhandled rejection would take
+    // the proxy down with it — for a failed analytics login.
+    logging.catch(() => {});
+  }
+  return logging;
+}
+
+/**
+ * The token, for a caller that will not wait.
+ *
+ * `wait: true` is for the owner-facing detail read, where a person has opened
+ * the Analytics screen on purpose and a slow answer beats no answer. Everything
+ * on the polled path takes the default and gets a refusal it can retry.
+ */
+async function authToken(wait = false): Promise<string> {
+  if (token && Date.now() < token.until) return token.value;
+  const p = warm();
+  if (wait) return p;
+  throw new Error("umami is waking up");
+}
+
+async function get<T>(path: string, timeoutMs = 5000, wait = false): Promise<T> {
+  const t = await authToken(wait);
   const base = umami().url;
   const r = await fetch(`${base}${path}`, {
     headers: { Authorization: `Bearer ${t}`, ...(await invoker(base)) },
@@ -241,10 +289,10 @@ function rank(rows: Rank | null | undefined, blank: string): [string, number][] 
  * headline numbers is a worse reading, not an unreadable one: the visitor count
  * is still true and the panel should still show it.
  */
-async function metric(websiteId: string, q: string, types: string[], timeoutMs?: number): Promise<Rank> {
+async function metric(websiteId: string, q: string, types: string[], timeoutMs?: number, wait = false): Promise<Rank> {
   for (const type of types) {
     try {
-      return await get<Rank>(`/api/websites/${websiteId}/metrics?${q}&type=${type}&limit=10`, timeoutMs);
+      return await get<Rank>(`/api/websites/${websiteId}/metrics?${q}&type=${type}&limit=10`, timeoutMs, wait);
     } catch {
       continue;
     }
@@ -492,14 +540,18 @@ export async function analyticsDetail(
   // asked for by a person who has just opened a screen and is willing to wait a
   // moment — and it may be waking a Cloud Run instance that scaled to zero, on
   // top of twenty queries it has to answer.
-  const BUDGET = 12_000;
+  const BUDGET = 30_000;
   let value: Detail | null = null;
   try {
     const [stats, series, active, ...ranked] = await Promise.all([
-      get<Stats>(`/api/websites/${websiteId}/stats?${q}`, BUDGET),
-      get<Series>(`/api/websites/${websiteId}/pageviews?${q}&unit=${encodeURIComponent(unit)}`, BUDGET).catch(() => null),
-      get<unknown>(`/api/websites/${websiteId}/active`, BUDGET).catch(() => null),
-      ...DIMENSIONS.map(([, names]) => metric(websiteId, q, names, BUDGET)),
+      // `wait` — the third argument — is the difference between this read and the
+      // polled one. Somebody opened this screen and is looking at it; waiting out
+      // a cold login here is the right trade, and the single-flight guard means
+      // these twenty-three calls cause one login between them.
+      get<Stats>(`/api/websites/${websiteId}/stats?${q}`, BUDGET, true),
+      get<Series>(`/api/websites/${websiteId}/pageviews?${q}&unit=${encodeURIComponent(unit)}`, BUDGET, true).catch(() => null),
+      get<unknown>(`/api/websites/${websiteId}/active`, BUDGET, true).catch(() => null),
+      ...DIMENSIONS.map(([, names]) => metric(websiteId, q, names, BUDGET, true)),
     ]);
 
     const visitors = num(stats.visitors ?? stats.uniques);

--- a/services/proxy/src/inject.ts
+++ b/services/proxy/src/inject.ts
@@ -8,8 +8,15 @@ import { config } from "./config";
 // Read from the same root the rest of the edge uses. This markup is injected
 // into other people's pages, so a stale literal here is our old brand showing
 // up on somebody's live site after the rename.
-const APP = `https://app.${config.rootDomain}`;
-const SITE = `https://${config.rootDomain}`;
+//
+// `rootDomains[0]` — CANONICAL, and the singular `config.rootDomain` this said
+// until now does not exist on config at all. TypeScript had been reporting it
+// since the multi-root cutover; at runtime it is `undefined`, so every badge and
+// every toolbar link injected into somebody else's page pointed at
+// `https://app.undefined`. Two dead links on other people's live sites, from a
+// property name that changed under a module nobody typechecked in CI.
+const APP = `https://app.${config.rootDomains[0]}`;
+const SITE = `https://${config.rootDomains[0]}`;
 
 /**
  * Everything only an owner may see — as SOURCE, not as a runtime branch.


### PR DESCRIPTION
The Analytics screen said "0 visitors" for every app while umami held the visitors — 179 page views and 10 people on `l3sgp` alone. Three independent failures, each verified against production before and after.

**1. `/stats` has three shapes and the control plane read one.** Production answers flat (`{"pageviews":179,"visitors":10}`); `lib/umami.ts` asked for `m.value`, which on a number is `undefined`. Every figure became 0 — a read that succeeds and means nothing. The edge already parsed all three shapes; the control plane now does too, plus the previous window, which `change` is computed from.

**2. The umami login sat on the request path.** Cold login measured at 13/20/25/26s against the running service; the edge waited behind a 10s deadline, so every cold read aborted — and analytics is looked at rarely, so cold was the common path. The polled read now refuses instantly and lets the next poll (3s later) find a warm token; only the owner-facing detail read waits. `scripts/setup-umami.sh` also stops scaling umami to zero.

**3. Two of seven live apps had no umami site at all.** `createAppRecord` provisions one and runs wherever a deploy runs — control plane, deploy worker, or deploy job — but only the control plane had `UMAMI_URL`; the other two were configured by copying its env once, before analytics existed. Both silent returns now name the app they cost, and the config lives in `cloudbuild.yaml` where all three read it.

Found while proving the above:

- `ensureWebsite` matched the canonical root only, so the rename to `thebay.cloud` would have missed every existing `supersonic.cv` site and minted a duplicate per app.
- The panel fetched pages and referrers on every read and dropped them; `change` was hardcoded `""`; the "bounce" tile was fed a field named `returning`; the owner's on/off switch had a route and no caller. All four fixed.
- `inject.ts` read `config.rootDomain`, which does not exist — every badge injected into someone else's live page linked to `https://app.undefined`.

**Tests:** 15 new (three `/stats` shapes, refused-vs-empty lists, path/url fallback, provisioning idempotence across both roots, one login per hundred concurrent polls). Proxy 186/186 green. The 13 failures in `apps/web` are pre-existing on this working tree and unrelated — verified by running them with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUYPQ1Gwkx8JrmJDQCLf14