### PR TITLE
A running deploy gets a window, a title, and its log back

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1383,85 +1383,161 @@ a.door { text-decoration: none; }
 .dfilm-bar .url.on { opacity: 1; }
 
 /* ------------------------------------------------------------
-   FULLSCREEN — a deploy running is the whole screen.
+   THE DRY DOCK — what `/new` becomes once a deploy is running.
 
-   The same treatment the ROOM already gives this film
-   (services/proxy/src/room-page.ts): the picture takes the window and
-   everything the page has to say is written over it, because a deploy is 90
-   seconds of nothing else happening and a 2.40:1 card in a column of white
-   spends the screen on the parts of the page nobody is reading.
+   It was the whole screen — a fixed overlay over this page's own form, with the
+   log written over the picture in a corner.
+   A full-bleed render with no chrome around it reads as a screensaver: nothing
+   on it said this was YOUR app being built, and a log of six ellipsised lines
+   over moving water is there to be glanced at rather than read.
 
-   The frame can no longer be assumed here, and that is handled in the film
+   So: a window. A title that says, in the film's own words, what is happening;
+   the log down the left where a log belongs and can be read to the end; the
+   picture taking everything left over. The chrome is the product's own light
+   palette and the frame is the only dark thing on screen, which is what makes
+   it read as a picture rather than as the page.
+
+   The film's aspect cannot be assumed here, and that is handled in the film
    rather than in CSS: `framed()` in ship-it.js holds the HORIZONTAL field each
-   shot was composed with, so a 16:9 window shows more sky and water instead of
-   cropping the bridge and the yard off the sides.
+   shot was composed with, so a taller or wider box shows more sky and water
+   instead of cropping the bridge and the yard off the sides.
    ------------------------------------------------------------ */
-/* `overflow: hidden` is structural, not tidiness: this is fixed, so anything
-   inside it that does not fit widens the DOCUMENT instead of the box, and then
-   every `right:` in here is measured off a viewport that is wider than the
-   screen — the name slides off the right edge and the buttons go with it.
-   100dvh rather than 100vh: on a phone the toolbars come and go, and vh is the
-   tallest of those states, which puts the stage bar under the browser's own
-   chrome for the first half of the deploy. */
-.cinema { position: fixed; inset: 0; z-index: 50; background: #0a100e; height: 100dvh; overflow: hidden; }
-/* absolute, not fixed: `.cinema` is the fixed box, and the words below have to
-   stack over the picture inside it. */
+/* The page the dock sits on: the content area under the top bar, which is
+   already exactly the window minus 56px of chrome — `.shell` is a 100dvh flex
+   column and `.content` is its one growing child, so `height: 100%` here has
+   something real to resolve against.
+
+   `overflow: hidden` is structural, not tidiness: `.content` scrolls, and a
+   window that overflowed would put a second scrollbar inside a box that is
+   supposed to be exactly one screen.
+
+   The explicit `minmax(0, 1fr)` tracks are the whole reason the window can be
+   narrower than its own content. An auto track is sized to the item's
+   max-content — a row of three buttons, a log line nobody wrapped — and the
+   `100%` below would then resolve against THAT, so on a phone the window came
+   out wider than the phone and everything on its right was clipped. */
+.dockpage { height: 100%; overflow: hidden; padding: clamp(10px, 2.2vh, 26px);
+  display: grid; place-items: center;
+  grid-template-columns: minmax(0, 1fr); grid-template-rows: minmax(0, 1fr); }
+
+/* `minmax(0, 1fr)` on the middle row and `min-height: 0` here are what let the
+   log scroll instead of growing the window: a grid item's default minimum is
+   its content, and a hundred-line build would otherwise push the footer off. */
+.drydock { width: min(1240px, 100%); height: 100%; min-height: 0;
+  display: grid; grid-template-rows: auto minmax(0, 1fr) auto;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--r-xl); overflow: hidden;
+  /* A panel on the page, not a sheet over it — so this is the lift the rest of
+     the product's cards have, not a modal's drop shadow. */
+  box-shadow: 0 1px 2px rgba(9, 14, 12, .04), 0 12px 32px -22px rgba(9, 14, 12, .3);
+  animation: drydock-in .42s var(--ease) both; }
+@keyframes drydock-in { from { opacity: 0; transform: translateY(10px) scale(.985); } }
+
+/* The title — the one place the ship is named as one, so the picture below
+   does not have to be decoded. */
+.drydock-head { display: flex; align-items: center; gap: 20px; padding: 15px 20px;
+  border-bottom: 1px solid var(--line); background: var(--card); }
+/* `min-width: 0` so the title column can give way rather than push the name
+   and the clock off the right edge of a narrow window. */
+.drydock-head .t { flex: 1 1 auto; min-width: 0; }
+.drydock-head .t b { display: block; font-size: 15.5px; font-weight: 600; letter-spacing: -.01em; color: var(--ink); }
+.drydock-head .t span { display: block; margin-top: 3px; font-size: 12.5px; color: var(--ink-2); }
+.drydock-head .meta { margin-left: auto; flex: none; display: flex; align-items: center; gap: 10px;
+  font-family: var(--mono); font-size: 12px; color: var(--ink-2); }
+.drydock-head .meta .nm { color: var(--ink); max-width: 22ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.drydock-head .meta .clock { font-variant-numeric: tabular-nums; }
+.drydock-head .dot { flex: none; width: 7px; height: 7px; border-radius: var(--r-pill);
+  background: var(--ink-3); animation: drydock-pulse 1.6s var(--ease) infinite; }
+.drydock-head .dot.live { background: var(--live); animation: none; }
+@keyframes drydock-pulse { 50% { opacity: .25; } }
+
+.drydock-body { display: grid; grid-template-columns: minmax(0, 320px) minmax(0, 1fr); min-height: 0; }
+
+/* The log, read as a log: all of it, oldest at the top, scrolled as it grows
+   (the page holds the ref and pins it to the bottom). */
+.drydock-log { display: flex; flex-direction: column; min-height: 0;
+  border-right: 1px solid var(--line); background: var(--paper); }
+.drydock-log .lh { padding: 10px 16px; border-bottom: 1px solid var(--line); font-family: var(--mono);
+  font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--faint); }
+.drydock-log .lb { flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain;
+  padding: 12px 16px 16px; font-family: var(--mono); font-size: 12px; line-height: 1.85; color: var(--ink-2); }
+.drydock-log .lb > div { display: flex; gap: 8px; }
+.drydock-log .lb .k { flex: none; width: 1em; color: var(--ink-3); }
+.drydock-log .lb .k.g { color: var(--live); }
+.drydock-log .lb .k.a { color: var(--ink); }
+/* Wrapped, not ellipsised: this column is narrow and a truncated line is the
+   thing the old overlay got wrong. */
+.drydock-log .lb .m { min-width: 0; overflow-wrap: anywhere; }
+.drydock-log .lb .working .m { color: var(--faint); }
+
+/* The picture. The dark ground is under the canvas rather than on it, so the
+   letterboxing a contained fit leaves is the same colour as the frame. */
+.drydock-film { position: relative; min-width: 0; background: #0a100e; }
+
+/* absolute, not fixed: `.drydock-film` is the box, and the film fills it. */
 .dfilm.full { position: absolute; inset: 0; border: 0; border-radius: 0; background: #0a100e; }
 .dfilm.full .dfilm-frame { position: absolute; inset: 0; }
 /* The holder the film appends its canvas into has to have a height of its own.
    It never needed one in the card: the canvas sizes itself with
    `aspect-ratio`, which resolves against an auto-height parent perfectly well.
    `height:100%` does not — it resolves to auto, and the picture would sit in a
-   band across the top of the window with dead space under it. */
+   band across the top of the frame with dead space under it. */
 .dfilm.full .dfilm-canvas { position: absolute; inset: 0; }
 /* `contain`, and it is not decoration: the film sizes its own drawing buffer
    to this box, so the fit is normally an identity — but an older film still
-   frames its buffer at 2.40:1, and stretched to a 16:9 window that is the
-   whole picture squashed. Contained, it letterboxes instead. */
+   frames its buffer at 2.40:1, and stretched to a taller box that is the whole
+   picture squashed. Contained, it letterboxes instead. */
 .dfilm.full .dfilm-frame canvas { width: 100%; height: 100%; aspect-ratio: auto; object-fit: contain; }
-/* The two bars were the cinema the card sat in. There is no card now. */
+/* The two bars were the cinema the card sat in. The window is that now. */
 .dfilm.full .dfilm-bar { display: none; }
-.dfilm.full .dfilm-slate { left: 22px; top: 18px; }
-.dfilm.full .dfilm-stagebar { left: 22px; right: 22px; bottom: 18px; }
+.dfilm.full .dfilm-slate { left: 16px; top: 13px; }
+.dfilm.full .dfilm-stagebar { left: 16px; right: 16px; bottom: 13px; }
 .dfilm.full .dfilm-fallback { position: absolute; left: 0; right: 0; top: 50%; transform: translateY(-50%); }
 
-/* what the page has to say, over the picture.
-   Top RIGHT, not spread across the top: the film puts its slate in the top
-   left corner and a name at the left edge would print over it. */
-.cinema-bar { position: absolute; right: 22px; top: 18px; display: flex; gap: 12px; align-items: baseline;
-  font-family: var(--mono); font-size: 12px; color: rgba(233,239,235,.55); pointer-events: none;
-  text-shadow: 0 1px 3px rgba(0,0,0,.75); }
-.cinema-bar .nm { color: #e9efeb; }
-.cinema-bar .clock { font-variant-numeric: tabular-nums; }
-/* The build's own words: the last six lines, which is what fits without the
-   log becoming the page. Above the film's stage bar, not over it. */
-.cinema-log { position: absolute; left: 22px; bottom: 52px; width: min(62ch, 52vw);
-  display: flex; flex-direction: column; font-family: var(--mono); font-size: 11.5px; line-height: 1.7;
-  color: rgba(233,239,235,.60); text-shadow: 0 1px 3px rgba(0,0,0,.75); pointer-events: none; }
-.cinema-log > div { display: flex; gap: 8px; min-width: 0; }
-.cinema-log .k { flex: none; width: 1em; color: rgba(233,239,235,.34); }
-.cinema-log .k.g { color: #4ec585; }
-.cinema-log .k.a { color: #7fa8d8; }
-.cinema-log .m { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-/* The address is the film's own endcard, bottom centre. These are what to do
-   about it, and they clear the stage bar on a short window. */
-.cinema-acts { position: absolute; left: 50%; bottom: max(64px, 7%); transform: translateX(-50%);
-  display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; max-width: calc(100vw - 44px); }
-/* Under the endcard is where these belong, and there is room for them there on
-   a wide window. On a narrower one the log — `min(62ch, 52vw)` — reaches the
-   middle of the screen, and a long line would run under the buttons, so they
-   go to the corner the stage bar leaves empty instead. */
-@media (max-width: 1200px) {
-  .cinema-acts { left: auto; right: 22px; bottom: 44px; transform: none; justify-content: flex-end; }
+/* What to do about it, once there is something to do. While the deploy runs
+   this row carries the one thing a person waiting actually wants told: that
+   the wait is normal, and that nothing here is faked. */
+.drydock-foot { display: flex; align-items: center; gap: 16px; padding: 12px 20px; min-height: 56px;
+  border-top: 1px solid var(--line); background: var(--card); }
+.drydock-foot .hint { font-size: 12px; color: var(--faint); }
+.drydock-foot .addr { font-family: var(--mono); font-size: 12.5px; color: var(--live); text-decoration: none;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.drydock-foot .addr:hover { text-decoration: underline; }
+/* `min-width: 0` is what makes `flex-wrap` mean anything here: a flex item's
+   default minimum is its content, so without it three buttons on a phone run
+   off the end of the row instead of stacking. */
+.drydock-foot .acts { margin-left: auto; min-width: 0; display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+
+/* One column, and the window becomes the screen again — but a window-shaped
+   one: the picture on top, the log under it still readable, the title still
+   saying what it is. The log gets a fixed share rather than `auto`, so a long
+   build cannot squeeze the film out of the frame. */
+@media (max-width: 900px) {
+  .dockpage { padding: 0; }
+  .drydock { width: 100%; height: 100%; border: 0; border-radius: 0; box-shadow: none; animation: none; }
+  .drydock-head { padding: 13px 16px; }
+  .drydock-head .t b { font-size: 14px; }
+  .drydock-head .t span { font-size: 11.5px; }
+  .drydock-head .meta .nm { display: none; }
+  .drydock-body { grid-template-columns: minmax(0, 1fr); grid-template-rows: minmax(0, 1fr) minmax(0, 38%); }
+  /* Second in the DOM because the log is the thing a screen reader should
+     reach first; first on screen because it is the thing to look at. */
+  .drydock-film { order: -1; }
+  .drydock-log { border-right: 0; border-top: 1px solid var(--line); }
+  /* One row of three buttons does not fit a phone next to an address, so the
+     footer stacks: the address on its own line, the buttons under it. */
+  .drydock-foot { padding: 10px 16px; flex-wrap: wrap; gap: 8px; text-align: center; }
+  .drydock-foot .hint .more { display: none; }
+  .drydock-foot .addr { flex: 1 0 100%; }
+  .drydock-foot .acts { flex: 1 0 100%; margin-left: 0; justify-content: center; }
 }
-@media (max-width: 640px) {
-  .cinema-log { width: auto; right: 22px; }
-  /* The film's own caption and the app's name are both one line across the top
-     of a screen that has room for one of them. The name is the one a person
-     came for. */
-  .dfilm.full .dfilm-slate { display: none; }
-  /* A phone has one column and the deploy is over: the address on the endcard
-     and what to do about it are the screen. The log has had its whole run. */
-  .cinema.done .cinema-log { display: none; }
-  .cinema-acts { left: 22px; right: 22px; bottom: 44px; justify-content: center; }
+/* A short window — a laptop with the browser at half height — has no room for
+   a subtitle and a log both. The subtitle is the one that has already been
+   read by the time this matters. */
+@media (max-height: 620px) {
+  .drydock-head .t span { display: none; }
+  .drydock-head { padding: 11px 16px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .drydock { animation: none; }
+  .drydock-head .dot { animation: none; }
 }

--- a/apps/web/app/new/page.tsx
+++ b/apps/web/app/new/page.tsx
@@ -57,6 +57,8 @@ export default function NewApp() {
   // below prints, so the picture can never be ahead of, or behind, the log.
   const [film, setFilm] = useState<FilmDrive>(FILM_START);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  // The dry dock's log column, pinned to its own bottom as lines arrive.
+  const logRef = useRef<HTMLDivElement>(null);
   const cloneToken = useRef<string | null>(null);
 
   // The GitHub door. `null` means "not asked yet" and is distinct from an empty
@@ -327,15 +329,22 @@ export default function NewApp() {
   }
 
   const busy = phase === "deploying";
+  /* The deploy has the page from the moment it starts. `/new` exists to do
+     exactly this one thing, so the form does not sit behind the picture
+     waiting to be dimmed — it is simply not what this page is about any more. */
+  const docked = phase === "deploying" || phase === "done";
 
-  /* Nothing scrolls behind the cinema. The overlay covers the window, so a
-     wheel over it would otherwise move a page nobody can see. */
+  /* The newest line is the one being waited on, so the log follows it down.
+     Only when the reader is already at the bottom: somebody who has scrolled
+     up to read what the detector said should not be yanked back every 250ms.
+     A line and a half of slack: a fractional scroll height rarely lands on
+     zero, and a reader one line off the bottom meant to be at it. */
   useEffect(() => {
-    if (phase !== "deploying" && phase !== "done") return;
-    const was = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = was; };
-  }, [phase]);
+    const el = logRef.current;
+    if (!el) return;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight > 40) return;
+    el.scrollTop = el.scrollHeight;
+  }, [logs, busy]);
 
   return (
     <div className="shell">
@@ -349,6 +358,7 @@ export default function NewApp() {
       </header>
 
       <div className="content">
+        {!docked && (
         <div className="wrap">
           <div className="ruler reveal" />
           <div className="newflow reveal" style={{ animationDelay: ".03s" }}>
@@ -556,12 +566,13 @@ export default function NewApp() {
               </div>
             )}
 
-            {/* A deploy that is RUNNING is the whole screen — see `cinema` at
-                the bottom of this file. What is left here is the wreckage of one
-                that failed: the words, without the picture. The film's break and
-                its repair drone are worth watching while the agent is actually
-                working, which is in the cinema; by the time this screen is up the
-                story is over and the fix below is what has to be read. */}
+            {/* A deploy that is RUNNING is watched in the dry dock — see
+                `drydock` at the bottom of this file. What is left here is the
+                wreckage of one that failed: the words, without the picture. The
+                film's break and its repair drone are worth watching while the
+                agent is actually working, which is in the window; by the time
+                this screen is up the story is over and the fix below is what
+                has to be read. */}
             {phase === "error" && (
               <div className="stage">
                 <div className="stage-head">
@@ -639,55 +650,115 @@ export default function NewApp() {
             )}
           </div>
         </div>
-      </div>
+        )}
 
-      {/* THE CINEMA — a deploy that is running, at the size it deserves.
+        {/* THE DRY DOCK — a deploy that is running, in a window built for it.
 
-          A container deploy is 90 seconds during which this page has exactly
-          one thing on it worth looking at, and it was a 2.40:1 card in the
-          middle of a column of white. It gets the window now, the same way the
-          room does at the app's own address, and everything the page was
-          saying underneath is said over the picture: the name and the clock in
-          one corner, the build's last six lines in the other.
+            A container deploy is 90 seconds during which this page has exactly
+            one thing on it worth looking at. That used to be the entire screen,
+            edge to edge, with the last six log lines written over the water in a
+            corner — and a full-bleed render with no chrome around it reads as a
+            screensaver. Nothing on it said this was YOUR app being built, and the
+            log was there to be glanced at rather than read.
 
-          Fixed, and mounted HERE rather than inside `.newflow` — an ancestor
-          with a transform on it (the reveal animation) is a containing block
-          for `position: fixed`, and this would have been fixed to that column
-          rather than to the window.
+            It is a window now, and the window does the explaining the picture
+            cannot: a title in the film's own language, the build's log down the
+            left where a log belongs, the picture taking the rest. She is built in
+            the yard, and when she goes out under the bridge the app is live.
 
-          It stays up when the deploy lands, because the ending is the point:
-          the sun comes up, she sails under the bridge, and the address is the
-          film's own endcard. These are what to do about it. */}
-      {(phase === "deploying" || phase === "done") && (
-        <div className={"cinema" + (phase === "done" ? " done" : "")}>
-          <DeployFilm drive={film} elapsed={elapsed} full />
-          <div className="cinema-bar">
-            <span className="nm">{slug || "…"}</span>
-            <span className="clock">{elapsed}s</span>
-          </div>
-          <div className="cinema-log">
-            {logs.slice(-6).map((l, i) => {
-              const ok = /^(Detected|Provision|Live at|Injecting|Agent fixed)/.test(l);
-              const agent = /^agent · /.test(l);
-              return (
-                <div key={`${i}-${l}`}>
-                  <span className={"k" + (ok ? " g" : agent ? " a" : "")}>{ok ? "✓" : agent ? "◆" : "·"}</span>
-                  <span className="m">{l}</span>
+            It is the PAGE, not a modal over one. `/new` is already the screen
+            for this — putting a window over its own form meant dimming a form
+            nobody could use and locking the scroll of a page nobody could see.
+            So the form gives way and the dock takes the content area, with the
+            top bar left where it is: a deploy runs on the server, and somebody
+            who wants to go and look at their other apps should be able to.
+
+            It stays up when the deploy lands, because the ending is the point:
+            the sun comes up, she sails under the bridge, and the address is the
+            film's own endcard. The footer is what to do about it. */}
+        {docked && (
+          <div className={"dockpage" + (phase === "done" ? " done" : "")}>
+            {/* No `role="dialog"`: this is the page's own content and its
+                heading says so. A dialog role here would tell a screen reader
+                to expect something dismissable, which it is not. */}
+            <section className="drydock">
+              <header className="drydock-head">
+                <div className="t">
+                  <b>{phase === "done" ? "Shipped." : "Your app is being shipped"}</b>
+                  {/* Only at the end. While she is being built the title says
+                      it, the picture shows it, and a line explaining the
+                      picture underneath is one voice too many. */}
+                  {phase === "done" && (
+                    <span>She left the yard in {elapsed}s and is under the bridge. Your app is live.</span>
+                  )}
                 </div>
-              );
-            })}
-            {busy && <div><span className="k">▸</span><span className="m">working…</span></div>}
+                <div className="meta">
+                  <span className={"dot" + (phase === "done" ? " live" : "")} />
+                  <span className="nm">{slug || "…"}</span>
+                  <span className="clock">{elapsed}s</span>
+                </div>
+              </header>
+
+              <div className="drydock-body">
+                {/* The build's own words — all of them, in order, wrapped rather
+                    than cut, and pinned to the bottom as they arrive. */}
+                <aside className="drydock-log">
+                  <div className="lh">Build log</div>
+                  <div className="lb" ref={logRef}>
+                    {logs.map((l, i) => {
+                      const ok = /^(Detected|Provision|Live at|Injecting|Agent fixed)/.test(l);
+                      const agent = /^agent · /.test(l);
+                      return (
+                        <div key={`${i}-${l}`}>
+                          <span className={"k" + (ok ? " g" : agent ? " a" : "")}>{ok ? "✓" : agent ? "◆" : "·"}</span>
+                          <span className="m">{l}</span>
+                        </div>
+                      );
+                    })}
+                    {busy && (
+                      <div className="working">
+                        <span className="k">▸</span>
+                        <span className="m">working…</span>
+                      </div>
+                    )}
+                  </div>
+                </aside>
+
+                <div className="drydock-film">
+                  <DeployFilm drive={film} elapsed={elapsed} full />
+                </div>
+              </div>
+
+              <footer className="drydock-foot">
+                {phase === "done" ? (
+                  <a className="addr" href={liveUrl} target="_blank" rel="noreferrer">
+                    {liveUrl.replace(/^https?:\/\//, "")}
+                  </a>
+                ) : (
+                  /* The only thing a person watching a 90-second wait wants told,
+                     and both halves of it are true: how long this takes, and that
+                     the picture is following the deploy rather than a clock. */
+                  <span className="hint">
+                    Most ships leave the yard in about 90 seconds.
+                    {/* Dropped on a narrow window, where the row has one line in
+                        it and the first half is the half that answers "how long". */}
+                    <span className="more"> The film waits on your deploy, not on a timer.</span>
+                  </span>
+                )}
+                {phase === "done" && (
+                  <div className="acts">
+                    <a className="btn" href={liveUrl} target="_blank" rel="noreferrer">Visit<ArrowRight size={13} /></a>
+                    <Link href={`/apps/${slug}`} className="btn primary">Open cockpit<ArrowRight size={13} /></Link>
+                    {/* The way out of a picture that has finished playing. */}
+                    <button className="btn" onClick={reset}><RotateCcw size={13} />Deploy another</button>
+                  </div>
+                )}
+              </footer>
+            </section>
           </div>
-          {phase === "done" && (
-            <div className="cinema-acts">
-              <a className="btn" href={liveUrl} target="_blank" rel="noreferrer">Visit<ArrowRight size={13} /></a>
-              <Link href={`/apps/${slug}`} className="btn primary">Open cockpit<ArrowRight size={13} /></Link>
-              {/* The way out of a picture that has finished playing. */}
-              <button className="btn" onClick={reset}><RotateCcw size={13} />Deploy another</button>
-            </div>
-          )}
-        </div>
-      )}
+        )}
+
+      </div>
 
       {/* Always dismissable: there is no state a person can be in where the
           only thing behind this modal is a locked account. Free is always


### PR DESCRIPTION
The deploy film was the whole screen — a fixed overlay over `/new`'s own form, with the app's name in one corner and the last six log lines written over the water in the other. It read as a screensaver: nothing said this was *your* app being built, and the log was there to be glanced at rather than read.

**It is the page now.** `/new` already exists to do this one thing, so the form gives way and the dock takes the content area under the top bar. No scrim, no dimmed form nobody can use, no `body` scroll lock, no `role="dialog"` — and the way out to Apps stays, because a deploy runs on the server whether or not this tab is watching.

**Inside the window**
- A title in the film's own language: *Your app is being shipped* → *Shipped.*
- The build's log down the left — all of it, wrapped rather than ellipsised, pinned to the bottom only while the reader is already there.
- The picture takes everything left over.
- The footer says how long this usually takes and that the film waits on the deploy rather than a timer; when she lands, the address and the buttons.
- Narrow screens: one column, picture on top, log under it, buttons in their own row.

**Not touched:** `DeployFilm` and `components/film/ship-it.js`. `framed()` already holds the horizontal field each shot was composed with, so a taller box shows more sky and water instead of cropping the yard off the sides.

Verified by rendering the real film bundle in headless Chrome at 1440×900 and 390×844, running and landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUYPQ1Gwkx8JrmJDQCLf14