### PR TITLE
The docs are live, so the README says where

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ work that out, ship it to a real address, and keep it alive.
 [![npm](https://img.shields.io/npm/v/@thebaycloud/cli?label=%40thebaycloud%2Fcli&color=e63f2c)](https://www.npmjs.com/package/@thebaycloud/cli)
 [![installs](https://img.shields.io/npm/dm/@thebaycloud/cli?label=installs&color=e63f2c)](https://www.npmjs.com/package/@thebaycloud/cli)
 [![license](https://img.shields.io/badge/license-AGPL--3.0-e63f2c)](LICENSE)
+[![docs](https://img.shields.io/badge/docs-bay.mintlify.app-e63f2c)](https://bay.mintlify.app)
 
-[**thebay.cloud**](https://thebay.cloud) · [Templates](https://thebay.cloud/templates) · [Changelog](https://thebay.cloud/changelog)
+[**thebay.cloud**](https://thebay.cloud) · [Docs](https://bay.mintlify.app) · [Templates](https://thebay.cloud/templates) · [Changelog](https://thebay.cloud/changelog)
 
 <br>
 


### PR DESCRIPTION
`apps/docs` is up at **https://bay.mintlify.app** — all 22 pages answering — and nothing in the repository pointed at it.

Two links, because they answer different questions:

- **A badge** in the row with npm, installs and licence, where a reader checks what a project has.
- **`Docs`** in the nav line, next to Templates and Changelog, where someone already looking for the site looks.

The badge names the host rather than saying "docs" twice, so it stays honest when the custom domain lands — `docs.thebay.cloud` is a one-token edit in both places.

Colour is `e63f2c`, matching the badges already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjS67sdmtAuSSD63uPhLqM