### PR TITLE
The landing sends a person to the documentation and an agent to the manual

### DIFF
--- a/apps/landing/app/404.md/route.ts
+++ b/apps/landing/app/404.md/route.ts
@@ -1,4 +1,4 @@
-import { BRAND, SITE } from "@/lib/brand";
+import { BRAND, DOCS_URL, SITE } from "@/lib/brand";
 
 /**
  * The 404 a terminal gets, in markdown.
@@ -27,7 +27,7 @@ reachable from here.
 
 - [The manual](${SITE}/llms.txt) — every command, in markdown. Also answers at
   \`/agents.md\`, \`/AGENTS.md\` and \`/cli.md\`, and at the bare domain under \`curl\`.
-- [Documentation](${SITE}/docs) — the same manual as a page.
+- [Documentation](${DOCS_URL}) — guides, the CLI reference, the config reference.
 - [Sitemap](${SITE}/sitemap.xml) — every page we publish, in six languages.
 - [Pricing](${SITE}/pricing) — what it costs.
 - [Changelog](${SITE}/changelog) — what shipped, with an [RSS feed](${SITE}/changelog.xml).

--- a/apps/landing/app/[locale]/docs/page.tsx
+++ b/apps/landing/app/[locale]/docs/page.tsx
@@ -1,134 +1,42 @@
-import type { Metadata } from "next";
-import { notFound } from "next/navigation";
-import { BRAND, CLI, DOCS_HOST, DOCS_URL, GITHUB_URL, PKG, SITE_NAME } from "@/lib/brand";
-import { getMessages, localePath } from "@/lib/i18n";
-import { DEFAULT_LOCALE, LOCALES, isLocale } from "@/lib/i18n/locales";
-import { alternatesFor } from "@/lib/i18n/alternates";
-import { SiteChrome } from "@/components/SiteChrome";
-import { BackLink } from "@/components/BackLink";
-import { manual } from "@/lib/manual";
-import "../changelog/changelog.css";
+import { notFound, permanentRedirect } from "next/navigation";
+import { DOCS_URL } from "@/lib/brand";
+import { isLocale } from "@/lib/i18n/locales";
 
 /**
- * The developer documentation, at the address a person guesses first.
+ * /docs is where the documentation used to be rendered. It now points at where
+ * the documentation is.
  *
- * The manual was already written, complete, and served — at `/llms.txt`, to
- * agents and to terminals. What it was not, was findable. Somebody who has heard
- * of this product and wants to know how the CLI works types `/docs`, and until
- * now that was a 404: the documentation existed at a URL you had to already know
- * the convention for.
+ * This page was `content/manual.md` as a page — the same file `/llms.txt`
+ * serves, given an address a person would guess. That was the right answer for
+ * exactly as long as the manual was the only documentation there was.
  *
- * So this is not a second set of documentation. It is `content/manual.md`,
- * rendered — the same file, the same words, the same day. See lib/manual.ts.
+ * `apps/docs` is now published, and it is not the same document: twenty-two
+ * pages against one file, with a CLI reference derived from `bay help --all`
+ * and a configuration reference derived from the exported types the control
+ * plane actually parses. Keeping both meant two descriptions of one product,
+ * overlapping on install, ship, databases, secrets, domains and logs, drifting
+ * from the first edit that touched one and not the other.
  *
- * The guides are a different document and live on Mintlify, at bay.mintlify.app.
- * This page links them rather than repeating them: the manual is the command
- * reference, complete and one screen long, and the guides are the long-form
- * walk-throughs. Both are linked from the top and the bottom of this page, so
- * neither is the one you have to already know about.
+ * So the split is by reader rather than by document. A person gets the site. An
+ * agent gets `/llms.txt`, which is untouched and still reads `content/manual.md`
+ * — one file, one request, no navigation to crawl. Neither is a lesser copy of
+ * the other, which is what makes this survivable.
  *
- * English only, like the changelog and the about page: a command reference that
- * is three releases out of date in five languages is worse than one that is
- * current in one.
+ * Permanent, because the address is not coming back. `lib/pages.ts` still lists
+ * it with `index: false`: middleware asks "is this a page" before routing, so
+ * dropping the entry answered a terminal asking for /docs with a 404 for a URL
+ * that does redirect — while `index: false` keeps it out of the sitemap, where a
+ * redirecting URL asks a crawler to index a hop.
+ *
+ * Dynamic, and NOT prerendered, which is the part that has to be said. With
+ * `generateStaticParams` this page built to a 308 carrying no Location header at
+ * all: an external redirect cannot be baked into a static route, so every locale
+ * answered with a dead end that looked like a redirect in the status line. The
+ * redirect has to be computed per request for the header to exist.
  */
-const WRAP = "mx-auto w-full max-w-[860px] px-[22px] min-[900px]:px-10";
-
-export function generateStaticParams() {
-  return LOCALES.map((locale) => ({ locale }));
-}
-
-export function generateMetadata({ params }: { params: { locale: string } }): Metadata {
-  return {
-    // The product name is in the title on purpose. This is the page somebody
-    // reaches by searching the product's name and the word "docs", and a title
-    // that says only "Documentation" is a title that matches nothing.
-    title: `${SITE_NAME} documentation — the ${CLI} CLI, end to end`,
-    description: `Developer documentation for ${SITE_NAME}: install the ${CLI} CLI from ${PKG}, ship an app, attach a database, set secrets, add a custom domain, and read the logs when a deploy fails.`,
-    alternates: alternatesFor("/docs", params.locale),
-  };
-}
+export const dynamic = "force-dynamic";
 
 export default function Docs({ params }: { params: { locale: string } }) {
   if (!isLocale(params.locale)) notFound();
-  const locale = isLocale(params.locale) ? params.locale : DEFAULT_LOCALE;
-  const t = getMessages(locale);
-  const { html, sections } = manual();
-
-  return (
-    <SiteChrome t={t} locale={locale}>
-      <section className={`${WRAP} pb-2 pt-[clamp(40px,5vw,72px)]`}>
-        <BackLink href={localePath(locale, "/")} label={BRAND} />
-        <h1 className="m-0 mt-8 font-sans text-balance text-[clamp(28px,3vw,38px)] font-normal leading-[1.14] tracking-[-0.024em]">
-          {SITE_NAME} documentation
-        </h1>
-        <p className="mt-4 max-w-[62ch] text-[17px] leading-[1.6] text-ink-2">
-          Everything {BRAND} can be told to do, from a terminal. This is the same
-          document an agent reads at{" "}
-          <a className="text-brand-ink hover:text-brand" href="/llms.txt">
-            /llms.txt
-          </a>
-          , rendered for a person — one source, so the two cannot drift.
-        </p>
-        <p className="mt-3 max-w-[62ch] text-[15px] leading-[1.6] text-ink-3">
-          Looking for the guides rather than the commands — databases, secrets, custom
-          domains, shipping from GitHub? Those are at{" "}
-          <a className="text-brand-ink hover:text-brand" href={DOCS_URL}>
-            {DOCS_HOST}
-          </a>
-          .
-        </p>
-      </section>
-
-      {/* The section list is the table of contents and the machine-readable
-          outline at once: every h2 in the manual, linked by the id lib/manual.ts
-          gives it, so a section can be quoted by URL. */}
-      <nav className={`${WRAP} pt-8`} aria-label="On this page">
-        <ul className="m-0 flex list-none flex-wrap gap-x-5 gap-y-2 border-y border-line p-0 py-4 text-[14.5px] text-ink-2">
-          {sections.map((s) => (
-            <li key={s.id}>
-              <a className="hover:text-brand-ink" href={`#${s.id}`}>
-                {s.title}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-
-      <section
-        className={`${WRAP} prose pb-10 pt-10`}
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
-
-      <section className={`${WRAP} pb-[clamp(72px,9vw,128px)]`}>
-        <div className="border-t border-line pt-6 text-[14.5px] text-ink-2">
-          <p className="m-0">
-            The guides, in twenty-two pages:{" "}
-            <a className="text-brand-ink hover:text-brand" href={DOCS_URL}>
-              {DOCS_HOST}
-            </a>
-            .
-          </p>
-          <p className="m-0 mt-2">
-            The same document in other shapes:{" "}
-            <a className="text-brand-ink hover:text-brand" href="/llms.txt">
-              /llms.txt
-            </a>{" "}
-            in markdown (also at <code>/agents.md</code>, <code>/AGENTS.md</code> and{" "}
-            <code>/cli.md</code>, and at the bare domain under <code>curl</code>),{" "}
-            <a className="text-brand-ink hover:text-brand" href={GITHUB_URL}>
-              the source on GitHub
-            </a>
-            , and{" "}
-            <a
-              className="text-brand-ink hover:text-brand"
-              href={`https://www.npmjs.com/package/${PKG}`}
-            >
-              {PKG}
-            </a>{" "}
-            on npm.
-          </p>
-        </div>
-      </section>
-    </SiteChrome>
-  );
+  permanentRedirect(DOCS_URL);
 }

--- a/apps/landing/app/[locale]/not-found.tsx
+++ b/apps/landing/app/[locale]/not-found.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { BRAND } from "@/lib/brand";
+import { BRAND, DOCS_URL } from "@/lib/brand";
 
 /**
  * The 404, written for both readers.
@@ -25,7 +25,7 @@ const WRAP = "mx-auto w-full max-w-[1040px] px-[22px] min-[900px]:px-10";
 
 const WAYS_BACK: { href: string; label: string; note: string }[] = [
   { href: "/llms.txt", label: "The manual", note: "every command, in markdown" },
-  { href: "/docs", label: "Documentation", note: "the same manual, as a page" },
+  { href: DOCS_URL, label: "Documentation", note: "guides, the CLI, the config" },
   { href: "/sitemap.xml", label: "Sitemap", note: "every page we publish" },
   { href: "/pricing", label: "Pricing", note: "what it costs" },
   { href: "/changelog", label: "Changelog", note: "what we shipped" },

--- a/apps/landing/components/SiteChrome.tsx
+++ b/apps/landing/components/SiteChrome.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { BRAND } from "@/lib/brand";
+import { BRAND, DOCS_URL } from "@/lib/brand";
 import { localePath, type Locale, type Messages } from "@/lib/i18n";
 import { LanguagePicker } from "./LanguagePicker";
 import { SiteNav } from "./SiteNav";
@@ -39,9 +39,9 @@ export function SiteChrome({
           <Link href={localePath(locale, "/pricing")} className="hover:text-ink">
             {t.nav.pricing}
           </Link>
-          <Link href={localePath(locale, "/docs")} className="hover:text-ink">
+          <a href={DOCS_URL} className="hover:text-ink">
             {t.footer.docs}
-          </Link>
+          </a>
           {/* A reader who landed on /privacy has no other way to /about from
               here: this footer is deliberately not the landing page's, and the
               three pages people check before trusting a platform were reachable

--- a/apps/landing/components/SiteNav.tsx
+++ b/apps/landing/components/SiteNav.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { APP_URL, BRAND, GITHUB_URL } from "@/lib/brand";
+import { APP_URL, BRAND, DOCS_URL, GITHUB_URL } from "@/lib/brand";
 import { cn } from "@/lib/utils";
 import { fill, localePath, type Locale, type Messages } from "@/lib/i18n";
 import { Stars } from "./Stars";
@@ -46,11 +46,11 @@ function resourceItems(t: Messages): Item[] {
     // The changelog is English only and lives outside the locale tree, so this
     // link is deliberately not run through localePath.
     { label: t.nav.changelog, href: "/changelog" },
-    // Was /llms.txt, which is the same document and the wrong end of it for
-    // somebody who clicked a menu item labelled Docs: a browser handed a
-    // markdown file renders it as one wall of unstyled text. /docs is that file
-    // as a page; the manual is still one click away from the bottom of it.
-    { label: t.nav.docs, href: "/docs" },
+    // The documentation site, which is not this codebase — see lib/brand.ts.
+    // Was /docs, which rendered the manual as a page; that page now redirects
+    // here, and pointing the menu at the redirect would spend a hop on every
+    // click. The manual itself is still one item down, under its own name.
+    { label: t.nav.docs, href: DOCS_URL },
     // Issues, not Discussions. Discussions is switched off on the repo, so
     // /discussions is a 404, and a menu item that leads nowhere is worse than one
     // that leads somewhere plainer. Point this back at /discussions the day it is

--- a/apps/landing/components/pages/Landing.tsx
+++ b/apps/landing/components/pages/Landing.tsx
@@ -19,7 +19,7 @@ import { ArrowRight, Check, Copy, Lock, Terminal } from "lucide-react";
 import { Mark } from "@/components/Mark";
 import { cn } from "@/lib/utils";
 import { Dithering, MeshGradient } from "@paper-design/shaders-react";
-import { APP_URL, BRAND, CLI, DOMAIN, GITHUB_REPO, GITHUB_URL, PKG } from "@/lib/brand";
+import { APP_URL, BRAND, CLI, DOCS_URL, DOMAIN, GITHUB_REPO, GITHUB_URL, PKG } from "@/lib/brand";
 import { TEMPLATES } from "@/lib/templates";
 import { onboardPrompt, selfhostPrompt } from "@/lib/prompts";
 import { Stars } from "@/components/Stars";
@@ -1309,7 +1309,7 @@ export default function Landing({ t, locale }: { t: Messages; locale: Locale }) 
             {
               head: t.footer.build,
               links: [
-                [t.footer.docs, "/docs"],
+                [t.footer.docs, DOCS_URL],
                 [t.footer.agentManual, "/llms.txt"],
                 [t.footer.shipAnApp, `${APP_URL}/new`],
                 [t.footer.signIn, APP_URL],

--- a/apps/landing/lib/pages.ts
+++ b/apps/landing/lib/pages.ts
@@ -23,7 +23,12 @@ export type Page = {
 export const PAGES: Page[] = [
   { path: "/", priority: 1, changeFrequency: "weekly", index: true },
   { path: "/pricing", priority: 0.8, changeFrequency: "monthly", index: true },
-  { path: "/docs", priority: 0.8, changeFrequency: "weekly", index: true },
+  // A permanent redirect to the documentation site, not a page. It stays on
+  // this list because middleware asks "is this a page" — dropping it answered
+  // a terminal asking for /docs with a 404 for a URL that does redirect.
+  // `index: false` keeps it out of the sitemap, where a redirecting URL asks a
+  // crawler to index a hop.
+  { path: "/docs", priority: 0.8, changeFrequency: "weekly", index: false },
   { path: "/changelog", priority: 0.6, changeFrequency: "weekly", index: true },
   { path: "/about", priority: 0.5, changeFrequency: "monthly", index: true },
   { path: "/contact", priority: 0.5, changeFrequency: "monthly", index: true },


### PR DESCRIPTION
`apps/docs` is published at **https://bay.mintlify.app**. Nothing on the site pointed at it, and `/docs` pointed at a *second* description of the same product — `content/manual.md`, rendered. Twenty-two pages against one file, overlapping on install, ship, databases, secrets, domains and logs.

## Split by reader, not by document

| | gets | which is |
|---|---|---|
| A person | `bay.mintlify.app` | the resources menu, both footers, the markdown 404, and `/docs` redirecting there |
| An agent | `/llms.txt` | untouched, still reading `content/manual.md` — one file, one request, nothing to crawl |

Neither is a lesser copy of the other. That is what makes the split hold instead of becoming the same drift under new names.

## Two things this got wrong first

Both caught by running the built site, not by reading the diff.

**Dropping `/docs` from `lib/pages.ts` 404'd it.** That file says why in its own header: middleware asks *"is this a page"*, not *"should this be indexed"*. The entry is back with `index: false` — out of the sitemap, where a redirecting URL asks a crawler to index a hop, but still a page as far as middleware is concerned.

**With `generateStaticParams` the route built to a 308 carrying no `Location` header at all.** An external redirect cannot be baked into a static route, so every locale answered with a dead end that read as a redirect in the status line. `force-dynamic` computes it per request.

Verified against `next build` + `next start`:

```
/docs      308 → https://bay.mintlify.app
/ru/docs   308 → https://bay.mintlify.app
/ja/docs   308 → https://bay.mintlify.app
/en/docs   308 → /docs          (middleware's existing default-locale strip)
/llms.txt  200, 283 lines       unchanged
sitemap    0 entries for /docs
```

The host stays in `lib/brand.ts`, so `docs.thebay.cloud` is one edit when the custom domain lands.

**Note:** `apps/landing` has no deploy workflow — it ships by hand — so this is not live until someone runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjS67sdmtAuSSD63uPhLqM